### PR TITLE
feat: add landing screen for README creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
 </head>
 
 <body>
+  <div id="landing">
+    <button class="btn" id="landing-import">Importar do GitHub</button>
+    <button class="btn" id="landing-create">Criar do zero</button>
+    <button class="btn" id="landing-open">Abrir arquivo</button>
+  </div>
+  <div id="app" hidden>
   <header>
     <div class="wrap">
       <div class="title">README Studio • Modular <span class="muted">(Pro)</span></div>
@@ -198,6 +204,7 @@
       Settings → Pages → Deploy from a branch.
     </section>
   </main>
+  </div>
 
   <script type="module" src="./src/main.js"></script>
 </body>

--- a/src/github/auth.js
+++ b/src/github/auth.js
@@ -1,0 +1,3 @@
+export async function startAuthFlow() {
+  console.log('TODO: implementar fluxo de autenticação do GitHub');
+}

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -11,6 +11,7 @@ import { attachHistory } from '../state/history.js';
 import { lintMarkdown } from '../utils/lint.js';
 import { discoverInstallations, discoverRepos, discoverReadme, analisarRepo, proporPR } from '../github/fetch.js';
 import { state, setInput, setAnalysis, setPR } from '../state/store.js';
+import { startAuthFlow } from '../github/auth.js';
 
 
 function toast(msg, type = 'info') {
@@ -64,6 +65,21 @@ export function bindUI() {
   const useEmoji = $('#useEmoji');
   const bakeEmoji = $('#bakeEmoji');
   const fetchBtn = $('#fetchGH');
+  const landing = $('#landing');
+  const app = $('#app');
+  const btnImport = $('#landing-import');
+  const btnCreate = $('#landing-create');
+  const btnOpen = $('#landing-open');
+  const defaultMd = `# Nome do Projeto\n\nBreve descrição…\n\n> [!TIP]\n> Use o painel à esquerda para inserir blocos prontos.\n`;
+
+  function showLanding() { landing.hidden = false; app.hidden = true; }
+  function hideLanding() { landing.hidden = true; app.hidden = false; }
+
+  if (!mdEl.value.trim()) {
+    showLanding();
+  } else {
+    hideLanding();
+  }
 
   function countStats(s) {
     const noCode = s.replace(/```[\s\S]*?```/g, '');
@@ -180,7 +196,7 @@ export function bindUI() {
     const inp = document.createElement('input'); inp.type = 'file'; inp.accept = '.md,text/markdown,text/plain';
     inp.onchange = () => {
       const f = inp.files[0]; if (!f) return;
-      const r = new FileReader(); r.onload = () => { mdEl.value = r.result; update(); };
+      const r = new FileReader(); r.onload = () => { mdEl.value = r.result; update(); hideLanding(); };
       r.readAsText(f);
     };
     inp.click();
@@ -281,7 +297,7 @@ export function bindUI() {
       log('parse spec', specStr, spec);
       const txt = await fetchReadme(spec, { forceRaw: !!$('#forceRaw')?.checked });
       if (!txt?.trim()) throw new Error('README vazio ou não encontrado');
-      mdEl.value = txt; update();
+      mdEl.value = txt; update(); hideLanding();
       log('README carregado. tamanho=', txt.length);
     } catch (err) {
       console.error(err); log('Erro', err?.message || String(err));
@@ -312,12 +328,31 @@ export function bindUI() {
     renderLint(res);
   };
 
-  mdEl.value = `# Nome do Projeto
+  btnCreate?.addEventListener('click', () => {
+    hideLanding();
+    mdEl.value = defaultMd;
+    update();
+  });
 
-Breve descrição…
+  btnOpen?.addEventListener('click', () => {
+    hideLanding();
+    $('#open').click();
+  });
 
-> [!TIP]
-> Use o painel à esquerda para inserir blocos prontos.
-`;
+  btnImport?.addEventListener('click', async () => {
+    await startAuthFlow();
+    const specStr = prompt('owner/repo · owner/repo@branch · URL do repo · URL RAW do README');
+    if (!specStr) return;
+    try {
+      const spec = parseRepoSpec(specStr);
+      const txt = await fetchReadme(spec, { forceRaw: !!$('#forceRaw')?.checked });
+      if (!txt?.trim()) throw new Error('README vazio ou não encontrado');
+      mdEl.value = txt; update();
+      hideLanding();
+    } catch (err) {
+      console.error(err); alert('Não consegui ler o README: ' + (err?.message || err));
+    }
+  });
+
   update();
 }

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,15 @@ body {
   font: 500 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto
 }
 
+#landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  height: 100vh;
+}
+
 a {
   color: var(--link)
 }


### PR DESCRIPTION
## Summary
- add landing screen to choose GitHub import, new README or local file
- keep user on landing until README content is loaded
- stub GitHub auth flow handler

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4ed11e734832bb0c40ac4976fed2a