### PR TITLE
feat: add repo wizard modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,21 +154,7 @@
 
     <section class="panel">
       <h3>Conectar repositório</h3>
-      <label>Instalação
-        <select id="sel-installation"></select>
-      </label>
-
-      <label>Repositório
-        <select id="sel-repo"></select>
-      </label>
-      <div class="grid">
-        <label>installation_id <input id="installation_id" placeholder="123456" /></label>
-        <label>owner <input id="owner" placeholder="org-ou-usuario" /></label>
-        <label>repo <input id="repo" placeholder="nome-do-repo" /></label>
-        <label>ref <input id="ref" value="main" /></label>
-        <label>readme_path <input id="readme_path" value="README.md" /></label>
-        <label>message <input id="message" value="docs: atualiza README (TOC)" /></label>
-      </div>
+      <button class="btn" id="btn-connect">Selecionar repositório…</button>
       <div class="actions">
         <button class="btn" id="btn-analisar">Analisar</button>
         <button class="btn" id="btn-pr">Criar PR</button>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,4 @@
-import { bindUI, bindWizard } from './ui/bindToolbar.js';
+import { bindUI } from './ui/bindToolbar.js';
 import { log } from './utils/log.js';
 log('Env', { protocol: location.protocol, host: location.host, href: location.href });
 bindUI();
-bindWizard();

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -8,51 +8,15 @@ import { toList, toCode, replaceSelection } from '../features/insert.js';
 import { fetchReadme, parseRepoSpec } from '../github/fetch.js';
 import { TPL } from '../features/templates.js';
 import { attachHistory } from '../state/history.js';
-import { lintMarkdown } from '../utils/lint.js';
-import { discoverInstallations, discoverRepos, discoverReadme, analisarRepo, proporPR } from '../github/fetch.js';
-import { state, setInput, setAnalysis, setPR } from '../state/store.js';
+import { openWizard } from './wizard.js';
+import { analisarRepo, proporPR } from '../github/fetch.js';
+import { state, setAnalysis, setPR } from '../state/store.js';
 
 
 function toast(msg, type = 'info') {
   const el = $('#toast'); if (!el) return;
   el.textContent = msg; el.className = `toast ${type}`;
   setTimeout(() => el.className = 'toast', 3000);
-}
-
-export async function bindWizard() {
-  // 1) listar instalações
-  const inst = await discoverInstallations();
-  const selInst = document.querySelector('#sel-installation');
-  selInst.innerHTML = inst.items.map(i =>
-    `<option value="${i.installation_id}">${i.account_login} (${i.target_type})</option>`
-  ).join('');
-  selInst.addEventListener('change', async (e) => {
-    const installation_id = e.target.value;
-    state.inputs.installation_id = installation_id;
-
-    // 2) listar repos da instalação
-    const repos = await discoverRepos(installation_id);
-    const selRepo = document.querySelector('#sel-repo');
-    selRepo.innerHTML = repos.items
-      .map(r => `<option value="${r.owner}/${r.repo}">${r.full_name}</option>`)
-      .join('');
-
-    // escolheu repo → 3) descobrir branch e README
-    selRepo.addEventListener('change', async ev => {
-      const [owner, repo] = ev.target.value.split('/');
-      const info = await discoverReadme(installation_id, owner, repo);
-      state.inputs.owner = owner;
-      state.inputs.repo = repo;
-      state.inputs.ref = info.ref || 'main';
-      state.inputs.readme_path = info.readme_path || 'README.md';
-
-      // opcional: preencher campos visíveis
-      document.querySelector('#owner').value = owner;
-      document.querySelector('#repo').value = repo;
-      document.querySelector('#ref').value = state.inputs.ref;
-      document.querySelector('#readme_path').value = state.inputs.readme_path;
-    }, { once: true });
-  });
 }
 
 
@@ -89,12 +53,19 @@ export function bindUI() {
     mdEl.hidden = !edit; prev.hidden = edit;
     if (!edit) update();
   }));
-
-  // inputs
-  ['installation_id', 'owner', 'repo', 'ref', 'readme_path', 'message'].forEach(id => {
-    const el = $(`#${id}`);
-    if (!el) return;
-    el.addEventListener('input', e => setInput(id, e.target.value));
+  $("#btn-connect")?.addEventListener("click", async () => {
+    try {
+      const res = await openWizard();
+      if (!res) return;
+      const { installation_id, owner, repo, ref, readme_path, readme } = res;
+      Object.assign(state.inputs, { installation_id, owner, repo, ref, readme_path });
+      mdEl.value = readme;
+      update();
+      toast("README carregado ✅", "ok");
+    } catch (err) {
+      console.error(err);
+      toast("Falha ao carregar README", "warn");
+    }
   });
 
   // analisar
@@ -102,7 +73,7 @@ export function bindUI() {
     try {
       const { installation_id, owner, repo, ref, readme_path } = state.inputs;
       if (!installation_id || !owner || !repo) {
-        toast('Preencha installation_id, owner e repo.', 'warn');
+        toast('Selecione um repositório primeiro.', 'warn');
         return;
       }
       $('#btn-analisar').disabled = true;

--- a/src/ui/wizard.js
+++ b/src/ui/wizard.js
@@ -1,0 +1,79 @@
+import { discoverInstallations, discoverRepos, discoverReadme, fetchReadme } from '../github/fetch.js';
+
+export async function openWizard() {
+  return new Promise(resolve => {
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    const box = document.createElement('div');
+    box.className = 'box';
+    modal.appendChild(box);
+    document.body.appendChild(modal);
+
+    let installation_id = '';
+    let owner = '';
+    let repo = '';
+    let ref = 'main';
+    let readme_path = 'README.md';
+
+    async function step1() {
+      box.innerHTML = `
+        <div class="progress">1/3</div>
+        <h3>Instalação</h3>
+        <select id="wiz-inst"></select>
+        <div class="actions"><button class="btn" id="next1">Próximo</button></div>`;
+      const inst = await discoverInstallations();
+      const sel = box.querySelector('#wiz-inst');
+      sel.innerHTML = inst.items.map(i => `<option value="${i.installation_id}">${i.account_login}</option>`).join('');
+      box.querySelector('#next1').onclick = () => {
+        installation_id = sel.value;
+        step2();
+      };
+    }
+
+    async function step2() {
+      box.innerHTML = `
+        <div class="progress">2/3</div>
+        <h3>Repositório</h3>
+        <input type="text" id="wiz-search" placeholder="Buscar..." />
+        <ul id="wiz-repos" class="repo-list"></ul>`;
+      const data = await discoverRepos(installation_id);
+      const repos = data.items || [];
+      const listEl = box.querySelector('#wiz-repos');
+      function render(list) {
+        listEl.innerHTML = list.map(r => `<li data-full="${r.owner}/${r.repo}">${r.full_name}</li>`).join('');
+      }
+      render(repos);
+      box.querySelector('#wiz-search').addEventListener('input', e => {
+        const q = e.target.value.toLowerCase();
+        render(repos.filter(r => r.full_name.toLowerCase().includes(q)));
+      });
+      listEl.onclick = e => {
+        const li = e.target.closest('li');
+        if (!li) return;
+        [owner, repo] = li.dataset.full.split('/');
+        step3();
+      };
+    }
+
+    async function step3() {
+      const info = await discoverReadme(installation_id, owner, repo);
+      ref = info.ref || 'main';
+      readme_path = info.readme_path || 'README.md';
+      box.innerHTML = `
+        <div class="progress">3/3</div>
+        <h3>Ajustes</h3>
+        <label>branch <input id="wiz-ref" type="text" value="${ref}" /></label>
+        <label>README <input id="wiz-path" type="text" value="${readme_path}" /></label>
+        <div class="actions"><button class="btn" id="finish">Concluir</button></div>`;
+      box.querySelector('#finish').onclick = async () => {
+        ref = box.querySelector('#wiz-ref').value.trim() || ref;
+        readme_path = box.querySelector('#wiz-path').value.trim() || readme_path;
+        const readme = await fetchReadme({ owner, repo, branch: ref, path: readme_path });
+        modal.remove();
+        resolve({ installation_id, owner, repo, ref, readme_path, readme });
+      };
+    }
+
+    step1();
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -299,3 +299,46 @@ main {
     height: 50vh
   }
 }
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+.modal .box {
+  background: var(--panel);
+  border: 1px solid var(--ring);
+  border-radius: 12px;
+  padding: 20px;
+  width: min(90%, 420px);
+}
+.modal .progress {
+  text-align: right;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.repo-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  max-height: 200px;
+  overflow: auto;
+}
+.repo-list li {
+  padding: 6px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.repo-list li:hover {
+  background: var(--soft);
+}
+.modal label {
+  display: block;
+  margin: 8px 0;
+}
+.modal input {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- replace manual repo inputs with three-step wizard modal
- load README via wizard and sync selection to internal state
- style modal and search UI for repo selection

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4ed28afa4832b811043ead45209b3