### PR TITLE
feat: reorganize toolbar with basic icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,20 @@
           </select>
         </label>
         <button class="btn" id="gen">Gerar README padrão</button>
-        <button class="btn" id="tocAuto">TOC automático</button>
-        <button class="btn" id="toList">→ Lista</button>
-        <button class="btn" id="toCode">→ Código</button>
 
         <div class="split"></div>
-        <button class="btn" id="undo">Undo</button>
-        <button class="btn" id="redo">Redo</button>
+        <div class="btn-group">
+          <button class="btn" id="bold" title="Negrito (Ctrl+B)"><b>B</b></button>
+          <button class="btn" id="heading" title="Heading (Ctrl+H)">H1</button>
+          <button class="btn" id="toList" title="Lista (Ctrl+L)">•</button>
+          <button class="btn" id="toCode" title="Código (Ctrl+Shift+C)">&lt;/&gt;</button>
+          <button class="btn" id="tocAuto" title="Sumário (Ctrl+T)">☰</button>
+          <button class="btn" id="undo" title="Undo (Ctrl+Z)">↶</button>
+          <button class="btn" id="redo" title="Redo (Ctrl+Y)">↷</button>
+          <button class="btn" id="toggleAdv" title="Ferramentas avançadas (Ctrl+M)">⚙️</button>
+        </div>
+
+        <div class="split"></div>
         <button class="btn" id="lint">Lint README</button>
         <button class="btn" id="copy">Copiar</button>
         <span class="muted" id="stats">0 palavras</span>
@@ -55,7 +62,7 @@
 
   <main class="wrap">
     <div class="grid">
-      <div class="panel">
+      <div class="panel" id="advPanel" hidden>
         <h3 style="margin:0 0 8px">Inserir bloco</h3>
         <div class="fieldset">
           <div class="row">

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -4,7 +4,7 @@ import { mdToHtml } from '../render/markdown.js';
 import { highlightAll } from '../render/highlight.js';
 import { applyEmojis } from '../features/emoji.js';
 import { buildTOC } from '../features/toc.js';
-import { toList, toCode, replaceSelection } from '../features/insert.js';
+import { toList, toCode, replaceSelection, getSelectionRanges } from '../features/insert.js';
 import { fetchReadme, parseRepoSpec } from '../github/fetch.js';
 import { TPL } from '../features/templates.js';
 import { attachHistory } from '../state/history.js';
@@ -163,6 +163,30 @@ export function bindUI() {
   $('#undo').onclick = () => history.undo();
   $('#redo').onclick = () => history.redo();
 
+  $('#toggleAdv').onclick = () => {
+    const p = $('#advPanel');
+    if (p) p.hidden = !p.hidden;
+  };
+  $('#bold').onclick = () => {
+    const sel = getSelectionRanges(mdEl);
+    const txt = sel.text || 'texto';
+    replaceSelection(mdEl, `**${txt}**`);
+    update();
+  };
+  $('#heading').onclick = () => {
+    const sel = getSelectionRanges(mdEl);
+    let text = sel.text;
+    if (!text) {
+      const v = mdEl.value;
+      let s = v.lastIndexOf('\n', sel.start - 1) + 1; if (s < 0) s = 0;
+      let e = v.indexOf('\n', sel.start); if (e < 0) e = v.length;
+      text = v.slice(s, e); mdEl.selectionStart = s; mdEl.selectionEnd = e;
+    }
+    const lines = text.split(/\r?\n/).map(l => l ? '# ' + l.replace(/^#+\s*/, '') : l);
+    replaceSelection(mdEl, lines.join('\n'));
+    update();
+  };
+
   $('#new').onclick = () => { if (confirm('Limpar conteúdo?')) { mdEl.value = ''; update(); } };
   $('#save').onclick = () => {
     const bake = bakeEmoji?.checked;
@@ -267,6 +291,16 @@ export function bindUI() {
     if (!toc) return alert('Nenhum heading encontrado');
     replaceSelection(mdEl, `\n## Sumário\n${toc}\n`);
     update();
+  });
+
+  mdEl.addEventListener('keydown', e => {
+    const k = e.key.toLowerCase();
+    if (e.ctrlKey && !e.shiftKey && k === 'b') { e.preventDefault(); $('#bold').click(); }
+    else if (e.ctrlKey && !e.shiftKey && k === 'h') { e.preventDefault(); $('#heading').click(); }
+    else if (e.ctrlKey && !e.shiftKey && k === 'l') { e.preventDefault(); $('#toList').click(); }
+    else if (e.ctrlKey && e.shiftKey && k === 'c') { e.preventDefault(); $('#toCode').click(); }
+    else if (e.ctrlKey && !e.shiftKey && k === 't') { e.preventDefault(); $('#tocAuto').click(); }
+    else if (e.ctrlKey && !e.shiftKey && k === 'm') { e.preventDefault(); $('#toggleAdv').click(); }
   });
 
 


### PR DESCRIPTION
## Summary
- group bold, heading, list, code, undo/redo and TOC into an icon toolbar
- hide advanced blocks behind a toggleable side panel
- add tooltips and keyboard shortcuts for the new toolbar actions

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a4ed323234832b970054f4238eeb98