### PR TITLE
Refine editor grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
   </header>
 
   <main class="wrap">
-    <div class="grid">
+    <div id="editorGrid">
       <div class="panel" id="advPanel" hidden>
         <h3 style="margin:0 0 8px">Inserir bloco</h3>
         <div class="fieldset">

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -153,7 +153,11 @@ export function bindUI() {
 
   $('#toggleAdv').onclick = () => {
     const p = $('#advPanel');
-    if (p) p.hidden = !p.hidden;
+    if (p) {
+      p.hidden = !p.hidden;
+      const g = $('#editorGrid');
+      if (g) g.classList.toggle('full', p.hidden);
+    }
   };
   $('#bold').onclick = () => {
     const sel = getSelectionRanges(mdEl);

--- a/styles.css
+++ b/styles.css
@@ -109,10 +109,15 @@ main {
   gap: 12px
 }
 
-.grid {
+
+#editorGrid {
   display: grid;
   grid-template-columns: 320px 1fr;
   gap: 12px
+}
+
+#editorGrid.full {
+  grid-template-columns: 1fr
 }
 
 .panel {
@@ -299,7 +304,7 @@ main {
 }
 
 @media (max-width:860px) {
-  .grid {
+  #editorGrid {
     grid-template-columns: 1fr
   }
 


### PR DESCRIPTION
## Summary
- target editor grid with dedicated `#editorGrid` id
- add `.full` helper class to collapse grid when advanced panel hidden
- toggle `.full` on advanced tools panel toggle

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a4f97fea74832b9d4a8965add82b02