### PR TITLE
Handle wizard async errors with retry UI

### DIFF
--- a/src/ui/wizard.js
+++ b/src/ui/wizard.js
@@ -15,19 +15,28 @@ export async function openWizard() {
     let ref = 'main';
     let readme_path = 'README.md';
 
+    function showError(msg, retryFn) {
+      box.innerHTML = `<p>${msg}</p><div class="actions"><button class="btn" id="retry">Tentar novamente</button></div>`;
+      box.querySelector('#retry').onclick = retryFn;
+    }
+
     async function step1() {
       box.innerHTML = `
         <div class="progress">1/3</div>
         <h3>Instalação</h3>
         <select id="wiz-inst"></select>
         <div class="actions"><button class="btn" id="next1">Próximo</button></div>`;
-      const inst = await discoverInstallations();
-      const sel = box.querySelector('#wiz-inst');
-      sel.innerHTML = inst.items.map(i => `<option value="${i.installation_id}">${i.account_login}</option>`).join('');
-      box.querySelector('#next1').onclick = () => {
-        installation_id = sel.value;
-        step2();
-      };
+      try {
+        const inst = await discoverInstallations();
+        const sel = box.querySelector('#wiz-inst');
+        sel.innerHTML = inst.items.map(i => `<option value="${i.installation_id}">${i.account_login}</option>`).join('');
+        box.querySelector('#next1').onclick = () => {
+          installation_id = sel.value;
+          step2();
+        };
+      } catch (e) {
+        showError('Não foi possível carregar instalações', step1);
+      }
     }
 
     async function step2() {
@@ -36,42 +45,60 @@ export async function openWizard() {
         <h3>Repositório</h3>
         <input type="text" id="wiz-search" placeholder="Buscar..." />
         <ul id="wiz-repos" class="repo-list"></ul>`;
-      const data = await discoverRepos(installation_id);
-      const repos = data.items || [];
-      const listEl = box.querySelector('#wiz-repos');
-      function render(list) {
-        listEl.innerHTML = list.map(r => `<li data-full="${r.owner}/${r.repo}">${r.full_name}</li>`).join('');
+      try {
+        const data = await discoverRepos(installation_id);
+        const repos = data.items || [];
+        const listEl = box.querySelector('#wiz-repos');
+        function render(list) {
+          listEl.innerHTML = list.map(r => `<li data-full="${r.owner}/${r.repo}">${r.full_name}</li>`).join('');
+        }
+        render(repos);
+        box.querySelector('#wiz-search').addEventListener('input', e => {
+          const q = e.target.value.toLowerCase();
+          render(repos.filter(r => r.full_name.toLowerCase().includes(q)));
+        });
+        listEl.onclick = e => {
+          const li = e.target.closest('li');
+          if (!li) return;
+          [owner, repo] = li.dataset.full.split('/');
+          step3();
+        };
+      } catch (e) {
+        showError('Não foi possível carregar repositórios', step2);
       }
-      render(repos);
-      box.querySelector('#wiz-search').addEventListener('input', e => {
-        const q = e.target.value.toLowerCase();
-        render(repos.filter(r => r.full_name.toLowerCase().includes(q)));
-      });
-      listEl.onclick = e => {
-        const li = e.target.closest('li');
-        if (!li) return;
-        [owner, repo] = li.dataset.full.split('/');
-        step3();
-      };
     }
 
     async function step3() {
-      const info = await discoverReadme(installation_id, owner, repo);
-      ref = info.ref || 'main';
-      readme_path = info.readme_path || 'README.md';
-      box.innerHTML = `
-        <div class="progress">3/3</div>
-        <h3>Ajustes</h3>
-        <label>branch <input id="wiz-ref" type="text" value="${ref}" /></label>
-        <label>README <input id="wiz-path" type="text" value="${readme_path}" /></label>
-        <div class="actions"><button class="btn" id="finish">Concluir</button></div>`;
-      box.querySelector('#finish').onclick = async () => {
-        ref = box.querySelector('#wiz-ref').value.trim() || ref;
-        readme_path = box.querySelector('#wiz-path').value.trim() || readme_path;
-        const readme = await fetchReadme({ owner, repo, branch: ref, path: readme_path });
-        modal.remove();
-        resolve({ installation_id, owner, repo, ref, readme_path, readme });
-      };
+      try {
+        const info = await discoverReadme(installation_id, owner, repo);
+        ref = info.ref || 'main';
+        readme_path = info.readme_path || 'README.md';
+        box.innerHTML = `
+          <div class="progress">3/3</div>
+          <h3>Ajustes</h3>
+          <label>branch <input id="wiz-ref" type="text" value="${ref}" /></label>
+          <label>README <input id="wiz-path" type="text" value="${readme_path}" /></label>
+          <div class="actions"><button class="btn" id="finish">Concluir</button></div>`;
+
+        box.querySelector('#finish').onclick = () => {
+          ref = box.querySelector('#wiz-ref').value.trim() || ref;
+          readme_path = box.querySelector('#wiz-path').value.trim() || readme_path;
+
+          async function attempt() {
+            try {
+              const readme = await fetchReadme({ owner, repo, branch: ref, path: readme_path });
+              modal.remove();
+              resolve({ installation_id, owner, repo, ref, readme_path, readme });
+            } catch (e) {
+              showError('Não foi possível carregar README', attempt);
+            }
+          }
+
+          attempt();
+        };
+      } catch (e) {
+        showError('Não foi possível carregar informações do README', step3);
+      }
     }
 
     step1();


### PR DESCRIPTION
## Summary
- Add reusable `showError` helper for wizard modal
- Wrap installation, repo, and README discovery calls in try/catch with retry button
- Retry README load on failure before closing modal

## Testing
- `node --check src/ui/wizard.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4f9532b30832b895fe4dddefb3eec