### PR TITLE
test: add parseRepoSpec tests

### DIFF
--- a/test/parseRepoSpec.test.js
+++ b/test/parseRepoSpec.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+globalThis.localStorage = { getItem: () => null };
+
+const { parseRepoSpec } = await import('../src/github/fetch.js');
+
+test('parse owner/repo', () => {
+  const spec = parseRepoSpec('owner/repo');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, undefined);
+  assert.strictEqual(spec.path, undefined);
+});
+
+test('parse owner/repo@dev', () => {
+  const spec = parseRepoSpec('owner/repo@dev');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, 'dev');
+  assert.strictEqual(spec.path, undefined);
+});
+
+test('parse https://github.com/owner/repo', () => {
+  const spec = parseRepoSpec('https://github.com/owner/repo');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, undefined);
+  assert.strictEqual(spec.path, undefined);
+});
+
+test('parse raw.githubusercontent URL', () => {
+  const url = 'https://raw.githubusercontent.com/owner/repo/main/README.md';
+  const spec = parseRepoSpec(url);
+  assert.deepStrictEqual(spec, { rawUrl: url });
+  assert.strictEqual(spec.owner, undefined);
+  assert.strictEqual(spec.repo, undefined);
+  assert.strictEqual(spec.branch, undefined);
+  assert.strictEqual(spec.path, undefined);
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for parseRepoSpec to cover owner, repo, branch, and path fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a504d5483c832b98eac72343949c0a