### PR TITLE
test: check lintLinksAndImages filters relative links

### DIFF
--- a/tests/lint.test.js
+++ b/tests/lint.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { lintLinksAndImages } from '../src/utils/lint.js';
+
+test('lintLinksAndImages returns only relative entries', () => {
+  const md = `
+[absolute](https://example.com)
+[anchor](#local)
+[relative](./file.md)
+`;
+
+  const result = lintLinksAndImages(md);
+
+  assert.deepStrictEqual(result, {
+    links: [ { text: 'relative', url: './file.md' } ],
+    images: []
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for lintLinksAndImages to ensure only relative links are returned when markdown includes absolute and anchor links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a505152bd4832bb0b5d999fc6817ad