### PR TITLE
feat: track original README and show diff

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -10,6 +10,7 @@ export const state = {
   },
   analysis: null,        // resposta de /analisar (findings, preview, base_sha)
   pr: null,              // resposta de /propor-pr
+  original_readme: '',   // conteúdo original carregado
 };
 
 export function setInput(key, value) {

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -80,6 +80,7 @@ export function bindUI() {
       if (!res) return;
       const { installation_id, owner, repo, ref, readme_path, readme } = res;
       Object.assign(state.inputs, { installation_id, owner, repo, ref, readme_path });
+      state.original_readme = readme;
       mdEl.value = readme;
       update();
       toast("README carregado ✅", "ok");
@@ -113,9 +114,9 @@ export function bindUI() {
       // preview antes/depois
       const preview = data.preview?.new_content_utf8 || '';
       $('#preview-after').innerHTML = mdToHtml(preview);
-      // diff entre original e proposto
+      // diff entre original carregado e conteúdo atual
       const dmp = new DiffMatchPatch();
-      const diff = dmp.diff_main(mdEl.value, preview);
+      const diff = dmp.diff_main(state.original_readme || '', mdEl.value);
       dmp.diff_cleanupSemantic(diff);
       if (diffView) diffView.innerHTML = dmp.diff_prettyHtml(diff);
       if (diffModal) diffModal.hidden = false;


### PR DESCRIPTION
## Summary
- store the originally loaded README in state
- capture README on wizard completion
- diff original vs. current README when analyzing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a50e8bfeb4832b8227f406e35121da