### PR TITLE
Use editor content with stored README SHA

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -6,7 +6,8 @@ export const state = {
     repo: '',
     ref: 'main',
     readme_path: 'README.md',
-    message: 'docs: atualiza README (TOC)'
+    message: 'docs: atualiza README (TOC)',
+    base_sha: '',           // SHA do README carregado
   },
   analysis: null,        // resposta de /analisar (findings, preview, base_sha)
   pr: null,              // resposta de /propor-pr

--- a/src/ui/wizard.js
+++ b/src/ui/wizard.js
@@ -92,9 +92,9 @@ export async function openWizard() {
         ref = box.querySelector('#wiz-ref').value.trim() || ref;
         readme_path = box.querySelector('#wiz-path').value.trim() || readme_path;
         try {
-          const readme = await fetchReadme({ owner, repo, branch: ref, path: readme_path });
+          const { text: readme, sha } = await fetchReadme({ owner, repo, branch: ref, path: readme_path });
           modal.remove();
-          resolve({ installation_id, owner, repo, ref, readme_path, readme });
+          resolve({ installation_id, owner, repo, ref, readme_path, readme, base_sha: sha });
         } catch(err) {
           alert(err.message === 'NETWORK_FAILURE' ? 'Falha de rede ao baixar README.' : 'Erro: ' + err.message);
           showError('Não foi possível carregar README', attempt);


### PR DESCRIPTION
## Summary
- track README base SHA when loading and expose via state
- use editor text and base SHA to create PRs
- return README text and SHA from `fetchReadme`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50e97e8f4832baf8bf65c6890331a