### PR TITLE
fix: ensure default branch is detected

### DIFF
--- a/src/github/fetch.js
+++ b/src/github/fetch.js
@@ -86,7 +86,7 @@ async function tryRaw(owner,repo,branches=['main','master','dev','stable'],paths
 }
 
 async function discoverDefaultBranch(owner,repo,token){
-  const {ok,status,error}=await fetchJSON(`https://api.github.com/repos/${owner}/${repo}`, token);
+  const { ok, status, data, error } = await fetchJSON(`https://api.github.com/repos/${owner}/${repo}`, token);
   if(error==='NETWORK_FAILURE') throw new Error('NETWORK_FAILURE');
   if(!ok){ if(status===404) throw new Error('NOT_FOUND_REPO_OR_PRIVATE'); throw new Error('Falha ao obter repo'); }
   // nota: não precisamos do default_branch aqui se fallback funcionar
@@ -179,3 +179,5 @@ export async function fetchReadme(spec,{forceRaw=false, token=getToken()}={}){
 
   throw new Error('Entrada não reconhecida');
 }
+
+export const __TESTING__ = { discoverDefaultBranch };

--- a/test/discoverDefaultBranch.test.js
+++ b/test/discoverDefaultBranch.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+globalThis.localStorage = { getItem: () => null };
+globalThis.document = { getElementById: () => null };
+
+const { __TESTING__ } = await import('../src/github/fetch.js');
+const { discoverDefaultBranch } = __TESTING__;
+
+test('discoverDefaultBranch', async (t) => {
+  await t.test('uses API default_branch', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = async () => new Response(JSON.stringify({ default_branch: 'dev' }), { status: 200 });
+    const branch = await discoverDefaultBranch('owner', 'repo');
+    assert.strictEqual(branch, 'dev');
+    global.fetch = originalFetch;
+  });
+
+  await t.test('defaults to main when absent', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = async () => new Response('{}', { status: 200 });
+    const branch = await discoverDefaultBranch('owner', 'repo');
+    assert.strictEqual(branch, 'main');
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing `default_branch` from GitHub API
- test `discoverDefaultBranch` for API branch and fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5170418f8832bb446fd0ddf41df52