### PR TITLE
feat: add demo mode option on landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,17 @@
 
 <body>
   <section class="panel" id="step-connect">
-    <h3>Conectar repositório</h3>
-    <button class="btn" id="btn-connect">Selecionar repositório…</button>
+    <h3>Bem-vindo ao README Studio</h3>
+    <p>Conecte um repositório ou experimente o editor.</p>
+    <div class="actions" style="display:flex;gap:8px;flex-wrap:wrap">
+      <button class="btn" id="btn-connect">Conectar GitHub</button>
+      <button class="btn" id="btn-demo">Experimentar sem GitHub</button>
+    </div>
+    <nav class="links" style="margin-top:12px;display:flex;gap:12px;flex-wrap:wrap">
+      <a href="/docs/" target="_blank">Docs</a>
+      <a href="/changelog" target="_blank">Changelog</a>
+      <a href="/examples" target="_blank">Examples Gallery</a>
+    </nav>
   </section>
   <div id="app" hidden>
   <header>

--- a/src/ui/bindToolbar.js
+++ b/src/ui/bindToolbar.js
@@ -97,6 +97,13 @@ export function bindUI() {
 
   $('#btn-connect')?.addEventListener('click', handleWizard);
 
+  $('#btn-demo')?.addEventListener('click', () => {
+    mdEl.value = '# Projeto Demo\n\nComece a escrever o README aqui...';
+    update();
+    setStep(2);
+    toast('Modo demo iniciado ✅', 'ok');
+  });
+
   // analisar
   $('#btn-analisar')?.addEventListener('click', async () => {
     try {


### PR DESCRIPTION
## Summary
- add landing CTAs for GitHub connection or demo mode
- handle demo mode to open editor with sample README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5197bfa5c832b8e310d8f5db9c1be