### PR TITLE
fix: load markdown-it from CDN in browser

### DIFF
--- a/src/utils/LIMITATIONS.md
+++ b/src/utils/LIMITATIONS.md
@@ -8,3 +8,7 @@ Consequentemente:
 - Extensões de Markdown fora do padrão podem ser ignoradas.
 
 Essas limitações devem ser consideradas ao evoluir o lint.
+
+> **Nota:** No navegador, o `markdown-it` é carregado via CDN
+(`https://esm.sh/markdown-it@14.1.0`) ou precisa ser incluído em um
+processo de bundling para ser resolvido.

--- a/src/utils/lint.js
+++ b/src/utils/lint.js
@@ -1,5 +1,12 @@
 import { githubSlugify as slug } from './githubSlug.js';
-import MarkdownIt from 'markdown-it';
+
+// Use local package in Node environments and a CDN in the browser.
+// `window` is undefined in Node, so we can decide at runtime.
+const { default: MarkdownIt } = await import(
+  typeof window === 'undefined'
+    ? 'markdown-it'
+    : 'https://esm.sh/markdown-it@14.1.0'
+);
 
 const mdParser = new MarkdownIt();
 


### PR DESCRIPTION
## Summary
- load markdown-it from a CDN when running in the browser, keep local package for Node
- document CDN/bundling requirement for markdown-it in browser builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52028a05c832ba6058dedb74f752f