### PR TITLE
build: configure @ui and @lib aliases

### DIFF
--- a/src/app/web/editor/[owner]/[repo]/page.tsx
+++ b/src/app/web/editor/[owner]/[repo]/page.tsx
@@ -1,10 +1,10 @@
-import Topbar from '../../../../../../src/ui/components/shell/Topbar.jsx';
-import StatusBar from '../../../../../ui/components/shell/StatusBar';
-import MdEditor from '../../../../../ui/components/editor/MdEditor';
-import MdPreview from '../../../../../ui/components/editor/MdPreview';
-import Inspector from '../../../../../ui/components/editor/Inspector';
-import { useEditorStore } from '../../../../../ui/state/editor';
-import { useRepoStore } from '../../../../../ui/state/repo';
+import Topbar from '@ui/components/shell/Topbar';
+import StatusBar from '@ui/components/shell/StatusBar';
+import MdEditor from '@ui/components/editor/MdEditor';
+import MdPreview from '@ui/components/editor/MdPreview';
+import Inspector from '@ui/components/editor/Inspector';
+import { useEditorStore } from '@ui/state/editor';
+import { useRepoStore } from '@ui/state/repo';
 import { useEffect, useState } from 'react';
 
 export default function EditorPage() {

--- a/src/app/web/layout.tsx
+++ b/src/app/web/layout.tsx
@@ -1,7 +1,7 @@
 import '../styles/globals.css';
 import '../styles/tokens.css';
 import Providers from './lib/providers';
-import AppSidebar from '../../ui/components/shell/AppSidebar';
+import AppSidebar from '@ui/components/shell/AppSidebar';
 
 export const metadata = { title: 'README Studio • Pro' };
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { bindUI } from './ui/bindToolbar.js';
+import { bindUI } from '@ui/bindToolbar.js';
 import { log } from './utils/log.js';
 log('Env', { protocol: location.protocol, host: location.host, href: location.href });
 bindUI();

--- a/src/ui/components/data/RepoPicker.tsx
+++ b/src/ui/components/data/RepoPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useRepoStore } from '../../state/repo';
-import Button from '../ui/button';
+import { useRepoStore } from '@ui/state/repo';
+import Button from '@ui/components/ui/button';
 
 export default function RepoPicker() {
   const { owner, repo, set } = useRepoStore();

--- a/src/ui/components/editor/Inspector.tsx
+++ b/src/ui/components/editor/Inspector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useUIStore } from '../../state/ui';
+import { useUIStore } from '@ui/state/ui';
 import TocPanel from './panels/TocPanel';
 import EmojiPanel from './panels/EmojiPanel';
 import SnippetLibrary from './panels/SnippetLibrary';

--- a/src/ui/components/shell/Topbar.tsx
+++ b/src/ui/components/shell/Topbar.tsx
@@ -1,7 +1,7 @@
 "use client";
-import RepoPicker from '../data/RepoPicker';
-import BranchSelect from '../data/BranchSelect';
-import Button from '../ui/button';
+import RepoPicker from '@ui/components/data/RepoPicker';
+import BranchSelect from '@ui/components/data/BranchSelect';
+import Button from '@ui/components/ui/button';
 import { Wand2 } from 'lucide-react';
 
 export default function Topbar({

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,8 +9,8 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@ui/*": ["packages/ui/src/*"],
-      "@lib/*": ["packages/lib/src/*"]
+      "@ui/*": ["src/ui/*"],
+      "@lib/*": ["src/lib/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- map `@ui/*` and `@lib/*` to `src/ui/*` and `src/lib/*`
- refactor imports to use `@ui` alias instead of deep relative paths

## Testing
- `npm test` *(fails: SyntaxError: The requested module 'markdown-it' does not provide an export named 'MarkdownIt')*
- `npm run lint` *(fails: trying to install TypeScript with Yarn)*
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a55c8eac90832b8f7d663386d47167