### PR TITLE
chore: add concurrent dev and build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node ./src/app/server.js",
+    "dev": "concurrently \"node src/app/api/server.js\" \"next dev\"",
     "test": "node --test",
     "start": "next start",
+    "build": "next build",
     "lint": "next lint"
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     "@types/pg-pool": "^2.0.6",
     "@types/tedious": "^4.0.14",
     "autoprefixer": "latest",
+    "concurrently": "^9.2.0",
     "playwright": "latest",
     "postcss": "latest",
     "tailwindcss": "latest",


### PR DESCRIPTION
## Summary
- run Fastify backend and Next.js dev server concurrently
- add `next build` script for production builds

## Testing
- `npm test` *(fails: 1 failing test)*
- `npm run lint` *(fails: TS6053: File 'tsconfig.base.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a55cd1f3b8832b8cabd7501bebaf7d