### PR TITLE
fix: trata sufixo .git e adiciona guia de deploy

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,38 @@
+# Tutorial de Deploy
+
+Este guia explica como publicar o Readme Studio Pro em um ambiente de produção.
+
+## Pré-requisitos
+
+- Node.js 20+
+- Conta no [Vercel](https://vercel.com) ou acesso a um servidor com Node.js
+
+## Passos
+
+1. **Clonar o repositório**
+   ```bash
+   git clone https://github.com/SEU_USUARIO/Readme-Studio-Pro.git
+   cd Readme-Studio-Pro
+   ```
+2. **Instalar dependências**
+   ```bash
+   npm install
+   ```
+3. **Configurar variáveis de ambiente**
+   Crie um arquivo `.env` com as chaves necessárias. Exemplo:
+   ```env
+   READMESTUDIO_BACKEND_URL=http://localhost:3001
+   ```
+4. **Gerar build de produção**
+   ```bash
+   npm run build
+   ```
+5. **Iniciar o servidor**
+   ```bash
+   npm start
+   ```
+6. **Deploy no Vercel (opcional)**
+   - Instale a CLI: `npm i -g vercel`
+   - Execute `vercel` e siga as instruções.
+
+Após o deploy, a aplicação estará disponível na URL gerada.

--- a/src/github/fetch.js
+++ b/src/github/fetch.js
@@ -102,14 +102,14 @@ export function parseRepoSpec(spec){
     const u=new URL(spec);
     if(/raw\.githubusercontent\.com$/.test(u.hostname)) return { rawUrl:u.href };
     if(/github\.com$/.test(u.hostname)){
-      const p=u.pathname.split('/').filter(Boolean); const owner=p[0], repo=p[1];
+      const p=u.pathname.split('/').filter(Boolean); const owner=p[0], repo=p[1]?.replace(/\.git$/,'');
       if(!owner||!repo) return null;
       if(p[2]==='blob'||p[2]==='tree'){ const branch=p[3]; const path=p.slice(4).join('/'); return { owner, repo, branch, path }; }
       return { owner, repo };
     }
   }catch{}
   const m=spec.match(/^([\w.-]+)\/([\w.-]+)(?:@([^:]+))?(?::(.+))?$/);
-  return m ? { owner:m[1], repo:m[2], branch:m[3], path:m[4] } : null;
+  return m ? { owner:m[1], repo:m[2].replace(/\.git$/,''), branch:m[3], path:m[4] } : null;
 }
 
 export async function fetchReadme(spec,{forceRaw=false, token=getToken()}={}){

--- a/test/parseRepoSpec.test.js
+++ b/test/parseRepoSpec.test.js
@@ -29,6 +29,30 @@ test('parse https://github.com/owner/repo', () => {
   assert.strictEqual(spec.path, undefined);
 });
 
+test('parse https://github.com/owner/repo.git', () => {
+  const spec = parseRepoSpec('https://github.com/owner/repo.git');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, undefined);
+  assert.strictEqual(spec.path, undefined);
+});
+
+test('parse owner/repo.git', () => {
+  const spec = parseRepoSpec('owner/repo.git');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, undefined);
+  assert.strictEqual(spec.path, undefined);
+});
+
+test('parse owner/repo.git@main', () => {
+  const spec = parseRepoSpec('owner/repo.git@main');
+  assert.strictEqual(spec.owner, 'owner');
+  assert.strictEqual(spec.repo, 'repo');
+  assert.strictEqual(spec.branch, 'main');
+  assert.strictEqual(spec.path, undefined);
+});
+
 test('parse raw.githubusercontent URL', () => {
   const url = 'https://raw.githubusercontent.com/owner/repo/main/README.md';
   const spec = parseRepoSpec(url);


### PR DESCRIPTION
## Summary
- normaliza repositórios com sufixo `.git`
- adiciona testes para novos casos de parse
- cria tutorial de deploy

## Testing
- `npm test`
- `npm run lint` *(interrompido; comando interativo)*

------
https://chatgpt.com/codex/tasks/task_e_68a5798783f0832b84bc5936453b3e9b