### PR TITLE
fix: add missing type declarations for markdown modules

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,2 @@
+declare module '@codemirror/lang-markdown';
+declare module 'remark-slug';


### PR DESCRIPTION
## Summary
- add ambient type declarations for `@codemirror/lang-markdown` and `remark-slug`
- include missing `next-env.d.ts`

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b5614c0832baaa150941efab263