### PR TITLE
fix: replace remark-slug with rehype-slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-markdown": "latest",
     "remark-breaks": "latest",
     "remark-gfm": "latest",
-    "remark-slug": "latest",
+    "rehype-slug": "latest",
     "zod": "latest",
     "zustand": "latest"
   },

--- a/src/ui/components/editor/MdPreview.tsx
+++ b/src/ui/components/editor/MdPreview.tsx
@@ -1,13 +1,16 @@
 "use client";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import remarkSlug from 'remark-slug';
 import remarkBreaks from 'remark-breaks';
+import rehypeSlug from 'rehype-slug';
 
 export default function MdPreview({ value }: { value: string }) {
   return (
     <div className="prose prose-tight dark:prose-invert max-w-none h-[calc(100dvh-12rem)] overflow-auto border rounded p-4">
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkSlug, remarkBreaks]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={[rehypeSlug]}
+      >
         {value}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
## Summary
- use `rehype-slug` instead of deprecated `remark-slug`
- adjust markdown preview to include `rehypeSlug`

## Testing
- `npm run build` *(fails: Type error in src/app/web/lib/github.ts)*
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a590660cb0832ba544a103e242a43c