### PR TITLE
fix: configure root layout and homepage redirect

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import '../ui/styles/globals.css';
+import '../ui/styles/tokens.css';
+
+export const metadata = { title: 'README Studio • Pro' };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="pt-BR" suppressHydrationWarning>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/web');
+}

--- a/src/app/web/layout.tsx
+++ b/src/app/web/layout.tsx
@@ -1,21 +1,13 @@
-import '../../ui/styles/globals.css';
-import '../../ui/styles/tokens.css';
 import Providers from './lib/providers';
 import AppSidebar from '@ui/components/shell/AppSidebar';
 
-export const metadata = { title: 'README Studio • Pro' };
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function WebLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
-      <body>
-        <Providers>
-          <div className="flex h-dvh">
-            <AppSidebar />
-            <div className="flex-1 flex flex-col">{children}</div>
-          </div>
-        </Providers>
-      </body>
-    </html>
+    <Providers>
+      <div className="flex h-dvh">
+        <AppSidebar />
+        <div className="flex-1 flex flex-col">{children}</div>
+      </div>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary
- add top-level layout with global styles
- redirect root path to `/web`
- simplify web layout to rely on root layout

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b3ed11a4832b93c9f7f049ffdbaf