### PR TITLE
fix: correct sidebar navigation paths

### DIFF
--- a/src/ui/components/shell/AppSidebar.tsx
+++ b/src/ui/components/shell/AppSidebar.tsx
@@ -3,12 +3,12 @@ import Link from 'next/link';
 import { BookOpen, Boxes, Settings, GitBranch, Layout, Bot } from 'lucide-react';
 
 const items = [
-  { href: '/(dashboard)', icon: Layout, label: 'Dashboard' },
-  { href: '/repositories', icon: GitBranch, label: 'Repositories' },
-  { href: '/editor/owner/repo', icon: BookOpen, label: 'README Studio' },
-  { href: '/templates', icon: Boxes, label: 'Templates' },
-  { href: '/automations', icon: Bot, label: 'Automations' },
-  { href: '/settings', icon: Settings, label: 'Settings' },
+  { href: '/web', icon: Layout, label: 'Dashboard' },
+  { href: '/web/repositories', icon: GitBranch, label: 'Repositories' },
+  { href: '/web/editor/owner/repo', icon: BookOpen, label: 'README Studio' },
+  { href: '/web/templates', icon: Boxes, label: 'Templates' },
+  { href: '/web/automations', icon: Bot, label: 'Automations' },
+  { href: '/web/settings', icon: Settings, label: 'Settings' },
 ];
 
 export default function AppSidebar() {


### PR DESCRIPTION
## Summary
- fix sidebar links to point at existing /web routes

## Testing
- `npm test`
- `curl -I http://localhost:3000/web`
- `curl -I http://localhost:3000/web/repositories`
- `curl -I http://localhost:3000/web/templates`
- `curl -I http://localhost:3000/web/automations`
- `curl -I http://localhost:3000/web/settings`


------
https://chatgpt.com/codex/tasks/task_e_68a5bd22acfc832b83e60c80e0b1dd32