### PR TITLE
chore: configure PostHog token via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Exemplo de configuração de variáveis de ambiente
+READMESTUDIO_BACKEND_URL=http://localhost:3001
+NEXT_PUBLIC_POSTHOG_KEY=SEU_TOKEN_DO_POSTHOG
+NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -22,6 +22,8 @@ Este guia explica como publicar o Readme Studio Pro em um ambiente de produção
    Crie um arquivo `.env` com as chaves necessárias. Exemplo:
    ```env
    READMESTUDIO_BACKEND_URL=http://localhost:3001
+   NEXT_PUBLIC_POSTHOG_KEY=SEU_TOKEN_DO_POSTHOG
+   NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
    ```
 4. **Gerar build de produção**
    ```bash

--- a/src/app/web/lib/providers.tsx
+++ b/src/app/web/lib/providers.tsx
@@ -7,11 +7,14 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 
 if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-    capture_pageview: true,
-    capture_pageleave: true,
-  });
+  const token = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (token) {
+    posthog.init(token, {
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+      capture_pageview: true,
+      capture_pageleave: true,
+    });
+  }
 }
 
 export default function Providers({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- ensure posthog only initializes when a token is present
- document required PostHog env vars

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bd1a7cbc832b84110ab95ff03e57