### PR TITLE
fix: validate webhook signature lengths before comparison

### DIFF
--- a/src/lib/github/verify.ts
+++ b/src/lib/github/verify.ts
@@ -4,5 +4,8 @@ export function verifyGitHubWebhook(body: string, signature256: string | null, s
   if (!signature256) return false;
   const hmac = crypto.createHmac("sha256", secret);
   const digest = "sha256=" + hmac.update(body).digest("hex");
+  if (digest.length !== signature256.length) {
+    return false;
+  }
   return crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(signature256));
 }


### PR DESCRIPTION
## Summary
- avoid timingSafeEqual throw by checking digest/signature lengths first

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cca6fc84832bb21434c1585d7217