### PR TITLE
fix: valida state na callback OAuth

### DIFF
--- a/src/app/api/github/oauth/callback/route.ts
+++ b/src/app/api/github/oauth/callback/route.ts
@@ -3,14 +3,24 @@ import { githubApp } from "@/lib/github/app";
 
 export const runtime = "nodejs";
 
+const STATE_COOKIE = "gh_oauth_state";
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const storedState = req.cookies.get(STATE_COOKIE)?.value;
 
-  if (!code) return NextResponse.redirect(new URL("/", req.url));
+  if (!code || !state || !storedState || state !== storedState) {
+    const res = NextResponse.redirect(new URL("/", req.url));
+    res.cookies.delete(STATE_COOKIE);
+    return res;
+  }
 
   const { authentication } = await githubApp.oauth.createToken({ code });
   // TODO: vincular token ao usuário local
 
-  return NextResponse.redirect(new URL("/dashboard", req.url));
+  const res = NextResponse.redirect(new URL("/dashboard", req.url));
+  res.cookies.delete(STATE_COOKIE);
+  return res;
 }


### PR DESCRIPTION
## Resumo
- valida parâmetro de `state` na callback do OAuth do GitHub
- rejeita requisições com `state` inválido ou ausente

## Testes
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5cca3d704832bb82ce896ab1d8efc