### PR TITLE
fix: refine installation token retrieval

### DIFF
--- a/src/lib/github/tokens.ts
+++ b/src/lib/github/tokens.ts
@@ -1,8 +1,9 @@
 import { githubApp } from "@/lib/github/app";
 
 export async function getInstallationToken(installationId: number) {
-  const jwtOctokit = await githubApp.getInstallationOctokit(installationId);
-  // @ts-ignore - octokit typing doesn't expose .auth
+  const jwtOctokit = (await githubApp.getInstallationOctokit(
+    installationId,
+  )) as typeof githubApp.octokit;
   const token = await jwtOctokit.auth({ type: "installation" });
   return { octokit: jwtOctokit, token };
 }


### PR DESCRIPTION
## Summary
- type jwtOctokit to include auth for installation tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cc9142b4832bb430c8cf012ce1e2