### PR TITLE
fix: validate GitHub App environment variables

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -8,7 +8,12 @@ export async function POST(req: NextRequest) {
   const rawBody = await req.text();
   const sig = req.headers.get("x-hub-signature-256");
   const event = req.headers.get("x-github-event");
-  const secret = process.env.GITHUB_APP_WEBHOOK_SECRET!;
+  const secret = process.env.GITHUB_APP_WEBHOOK_SECRET;
+  if (!secret)
+    return NextResponse.json(
+      { error: "GITHUB_APP_WEBHOOK_SECRET not configured" },
+      { status: 500 }
+    );
 
   const ok = verifyGitHubWebhook(rawBody, sig, secret);
   if (!ok) return NextResponse.json({ error: "Invalid signature" }, { status: 401 });

--- a/src/lib/github/app.ts
+++ b/src/lib/github/app.ts
@@ -6,11 +6,21 @@ function getPrivateKey(): string {
   return Buffer.from(b64, "base64").toString("utf8");
 }
 
+function requiredEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+const appId = requiredEnvVar("GITHUB_APP_ID");
+const clientId = requiredEnvVar("GITHUB_APP_CLIENT_ID");
+const clientSecret = requiredEnvVar("GITHUB_APP_CLIENT_SECRET");
+
 export const githubApp = new App({
-  appId: process.env.GITHUB_APP_ID!,
+  appId,
   privateKey: getPrivateKey(),
   oauth: {
-    clientId: process.env.GITHUB_APP_CLIENT_ID!,
-    clientSecret: process.env.GITHUB_APP_CLIENT_SECRET!,
+    clientId,
+    clientSecret,
   },
 });


### PR DESCRIPTION
## Summary
- ensure GitHub App env vars are present before initializing the app
- guard GitHub webhook route when webhook secret is missing

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc83068c832b8b62804ab0046a85