### PR TITLE
feat: implement GitHub file API

### DIFF
--- a/src/app/api/github/file/route.ts
+++ b/src/app/api/github/file/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { githubApp } from "@/lib/github/app";
+import { findInstallationIdForRepo } from "@/lib/github/installations";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const owner = searchParams.get("owner");
+  const repo = searchParams.get("repo");
+  const path = searchParams.get("path");
+
+  if (!owner || !repo || !path) {
+    return NextResponse.json(
+      { error: "MISSING_PARAMS", detail: "owner, repo, path" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const installationId = await findInstallationIdForRepo(owner, repo);
+    const octokit = await githubApp.getInstallationOctokit(installationId);
+    const { data } = await octokit.request(
+      "GET /repos/{owner}/{repo}/contents/{path}",
+      { owner, repo, path }
+    );
+    return NextResponse.json({ content: data.content, sha: data.sha });
+  } catch (e: any) {
+    const status = e.status || 500;
+    const message = e.response?.data?.message || e.message || "Internal error";
+    console.error("[github/file GET]", e);
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { owner, repo, path, content, message, sha } = body || {};
+    if (!owner || !repo || !path || !content || !message || !sha) {
+      return NextResponse.json(
+        { error: "MISSING_FIELDS", detail: "owner, repo, path, content, message, sha" },
+        { status: 400 }
+      );
+    }
+    const installationId = await findInstallationIdForRepo(owner, repo);
+    const octokit = await githubApp.getInstallationOctokit(installationId);
+    const { data } = await octokit.request(
+      "PUT /repos/{owner}/{repo}/contents/{path}",
+      { owner, repo, path, message, content, sha }
+    );
+    return NextResponse.json({ content: data.content, commit: data.commit });
+  } catch (e: any) {
+    const status = e.status || 500;
+    const message = e.response?.data?.message || e.message || "Internal error";
+    console.error("[github/file PUT]", e);
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/web/lib/github.ts
+++ b/src/app/web/lib/github.ts
@@ -1,9 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 
 export async function fetchFileContent(owner: string, repo: string, path: string): Promise<string> {
-  // TODO: substituir por chamada real à API (GitHub REST ou conector interno)
   const res = await fetch(`/api/github/file?owner=${owner}&repo=${repo}&path=${encodeURIComponent(path)}`);
-  if (!res.ok) throw new Error('Falha ao obter ficheiro');
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Falha ao obter ficheiro');
+  }
   const data = await res.json();
   return atob(data.content);
 }
@@ -25,13 +27,15 @@ export function useUpdateFile() {
       message: string;
       sha: string;
     }) => {
-      // TODO: chamar rota interna ou conector que faz PUT no GitHub
-      const res = await fetch('/api/github/update', {
-        method: 'POST',
+      const res = await fetch('/api/github/file', {
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ owner, repo, path, content: btoa(content), message, sha }),
       });
-      if (!res.ok) throw new Error('Falha ao atualizar ficheiro');
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'Falha ao atualizar ficheiro');
+      }
       return res.json();
     },
     onMutate: async () => {

--- a/src/lib/github/installations.ts
+++ b/src/lib/github/installations.ts
@@ -1,0 +1,19 @@
+import { githubApp } from "@/lib/github/app";
+import { prisma } from "@/lib/db/client";
+
+/**
+ * Resolve installation id for a repo, caching in Prisma.
+ */
+export async function findInstallationIdForRepo(owner: string, repo: string): Promise<number> {
+  const link = await prisma.repoLink.findFirst({ where: { owner, repo } });
+  if (link) return link.installationId;
+
+  const { data } = await githubApp.octokit.request(
+    "GET /repos/{owner}/{repo}/installation",
+    { owner, repo }
+  );
+  await prisma.repoLink.create({
+    data: { owner, repo, installationId: data.id },
+  });
+  return data.id;
+}


### PR DESCRIPTION
## O que foi feito
- expõe rota `/api/github/file` com GET e PUT via Octokit
- usa token da instalação atual para autenticar
- melhora mensagens de erro e resolve installationId reutilizável

## Como testar
- `pnpm test`
- `curl http://localhost:3000/api/github/file?owner=OWNER&repo=REPO&path=README.md`

## Notas
- `pnpm lint` falha por falta de configuração ESLint


------
https://chatgpt.com/codex/tasks/task_e_68a5d126fa64832b9de32a54a841a969