### PR TITLE
feat: persist installation and handle push events

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyGitHubWebhook } from "@/lib/github/verify";
+import { prisma } from "@/lib/db/client";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,11 +21,35 @@ export async function POST(req: NextRequest) {
 
   const payload = JSON.parse(rawBody);
 
-  if (event === "installation") {
-    // TODO: persist installation.id
+  if (payload.installation?.id) {
+    await prisma.installation.upsert({
+      where: { installationId: payload.installation.id },
+      update: {
+        accountLogin: payload.installation.account?.login || "",
+        accountId: payload.installation.account?.id || 0,
+      },
+      create: {
+        installationId: payload.installation.id,
+        accountLogin: payload.installation.account?.login || "",
+        accountId: payload.installation.account?.id || 0,
+      },
+    });
   }
-  if (event === "push") {
-    // TODO: handle push events
+
+  switch (event) {
+    case "push":
+      console.log(
+        "push",
+        payload.repository?.full_name,
+        payload.head_commit?.id,
+        payload.head_commit?.message
+      );
+      break;
+    case "installation":
+      console.log("installation", payload.installation?.id);
+      break;
+    default:
+      break;
   }
 
   return NextResponse.json({ received: true });


### PR DESCRIPTION
## O que foi feito
- persiste `installation.id` ao receber webhooks
- adiciona switch para tratar eventos `push`

## Como testar
- `pnpm test`

## Notas
- `pnpm lint` requer configuração interativa e falhou no ambiente

------
https://chatgpt.com/codex/tasks/task_e_68a5d12b19a8832ba337b54d33b66d3d