### PR TITLE
feat: save README and open PR

### DIFF
--- a/src/ui/components/data/SyncBadge.tsx
+++ b/src/ui/components/data/SyncBadge.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { useState } from 'react';
 
-export default function SyncBadge() {
-  const [state] = useState<'idle' | 'saving' | 'error'>('idle');
+export default function SyncBadge({
+  state,
+}: {
+  state: "idle" | "saving" | "error";
+}) {
   const label =
-    state === 'saving' ? 'Salvando…' : state === 'error' ? 'Erro' : 'Sincronizado';
+    state === "saving" ? "Salvando…" : state === "error" ? "Erro" : "Sincronizado";
   return (
     <span className="text-xs px-2 py-0.5 rounded bg-subtle">
       {label}

--- a/src/ui/components/shell/StatusBar.tsx
+++ b/src/ui/components/shell/StatusBar.tsx
@@ -5,23 +5,36 @@ export default function StatusBar({
   autosaveAt,
   branch,
   lintCount,
+  prUrl,
+  syncState,
+  error,
 }: {
   autosaveAt?: string;
   branch?: string;
   lintCount?: number;
+  prUrl?: string;
+  syncState: 'idle' | 'saving' | 'error';
+  error?: string;
 }) {
   return (
     <div className="h-8 border-t text-xs px-3 flex items-center justify-between">
       <div className="flex items-center gap-3">
-        <SyncBadge />
+        <SyncBadge state={syncState} />
         <span>
           Branch: <b>{branch ?? '-'}</b>
         </span>
         <span>
           Lint: <b>{lintCount ?? 0}</b>
         </span>
+        {prUrl && (
+          <span>
+            PR: <a href={prUrl} target="_blank" className="underline">abrir</a>
+          </span>
+        )}
       </div>
-      <div className="text-muted">Autosave: {autosaveAt ?? '—'}</div>
+      <div className="text-muted">
+        {error ? <span className="text-red-600">{error}</span> : `Autosave: ${autosaveAt ?? '—'}`}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
# Título: save README and open PR

## O que foi feito
- implementado fluxo de salvamento do README via Git
- adicionada mutation para criar PR e exibir link retornado
- trocado alert por feedback na UI e tratamento de erros

## Como testar
- `pnpm test`
- `pnpm lint` *(falha por configuração interativa)*

## Notas
- requer SHA real do README e endpoints válidos para persistência completa


------
https://chatgpt.com/codex/tasks/task_e_68a5d0e46d74832bb1339af4d0c2c39b