### PR TITLE
feat: add toast notifications

### DIFF
--- a/src/ui/components/common/Toast.tsx
+++ b/src/ui/components/common/Toast.tsx
@@ -1,4 +1,54 @@
 "use client";
-export default function Toast() {
-  return null; // TODO: toast notification
+import { useEffect } from 'react';
+import {
+  useToastStore,
+  dismissToast,
+  Toast,
+  ToastVariant,
+} from '@ui/state/toast';
+
+const variantStyles: Record<ToastVariant | undefined, string> = {
+  info: 'bg-accent text-white',
+  success: 'bg-success text-white',
+  warn: 'bg-accent text-white',
+  error: 'bg-danger text-white',
+  undefined: 'bg-accent text-white',
+};
+
+function ToastItem({ t }: { t: Toast }) {
+  useEffect(() => {
+    const id = setTimeout(() => dismissToast(t.id), t.duration ?? 3000);
+    return () => clearTimeout(id);
+  }, [t.id, t.duration]);
+  return (
+    <div
+      role="status"
+      className={`pointer-events-auto flex items-start gap-2 rounded px-4 py-2 shadow-2 ${variantStyles[t.variant]}`}
+    >
+      <span className="flex-1">{t.message}</span>
+      <button
+        onClick={() => dismissToast(t.id)}
+        aria-label="Dismiss"
+        className="text-white/80 hover:text-white"
+      >
+        ×
+      </button>
+    </div>
+  );
 }
+
+export default function Toast() {
+  const toasts = useToastStore((s) => s.toasts);
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed top-4 right-4 z-50 flex w-80 flex-col gap-2"
+    >
+      {toasts.map((t) => (
+        <ToastItem key={t.id} t={t} />
+      ))}
+    </div>
+  );
+}
+
+export { enqueueToast, dismissToast } from '@ui/state/toast';

--- a/src/ui/state/toast.ts
+++ b/src/ui/state/toast.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+
+export type ToastVariant = 'info' | 'success' | 'warn' | 'error';
+
+export interface Toast {
+  id: string;
+  message: string;
+  variant?: ToastVariant;
+  duration?: number; // ms
+}
+
+interface ToastStore {
+  toasts: Toast[];
+  enqueue: (t: Omit<Toast, 'id'> & { id?: string }) => string;
+  dismiss: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  enqueue: (t) => {
+    const id = t.id ?? Math.random().toString(36).slice(2);
+    set((s) => ({ toasts: [...s.toasts, { ...t, id }] }));
+    return id;
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((tt) => tt.id !== id) })),
+}));
+
+export function enqueueToast(t: Omit<Toast, 'id'>) {
+  return useToastStore.getState().enqueue(t);
+}
+
+export function dismissToast(id: string) {
+  useToastStore.getState().dismiss(id);
+}


### PR DESCRIPTION
## O que foi feito
- implementado componente de toast com empilhamento e acessibilidade
- exposto API para enfileirar e dispensar toasts

## Como testar
- `pnpm test`

## Notas
- toasts expiram após 3s e podem ser fechados via botão

------
https://chatgpt.com/codex/tasks/task_e_68a5d1554e0c832babbb8de8a98ff6a5