### PR TITLE
feat: wire inspector data panels

### DIFF
--- a/src/ui/components/editor/AnalysisBar.tsx
+++ b/src/ui/components/editor/AnalysisBar.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from '../../state/editor';
 import { useState } from 'react';
 import { lintMarkdown } from '../../../utils/lint.js';
 import DiffMatchPatch from 'diff-match-patch';
+import { useAnalysisStore } from '../../state/analysis';
 
 export default function AnalysisBar({
   setLintCount,
@@ -14,9 +15,15 @@ export default function AnalysisBar({
   const [analysis, setAnalysis] = useState<any>();
   const [original, setOriginal] = useState('');
   const [diffHtml, setDiffHtml] = useState<string>();
+  const { setLintIssues, setAISuggestions } = useAnalysisStore();
 
   const analyze = () => {
     const res = lintMarkdown(content);
+    setLintIssues(res.issues);
+    const suggestions = res.issues
+      .filter((i) => i.sev !== 'ok')
+      .map((i) => `Revisar: ${i.msg}`);
+    setAISuggestions(suggestions);
     setAnalysis(res);
     setLintCount(res.issues.length);
     setOriginal(content);

--- a/src/ui/components/editor/Inspector.tsx
+++ b/src/ui/components/editor/Inspector.tsx
@@ -4,6 +4,8 @@ import TocPanel from './panels/TocPanel';
 import EmojiPanel from './panels/EmojiPanel';
 import SnippetLibrary from './panels/SnippetLibrary';
 import AssetPicker from './panels/AssetPicker';
+import LintPanel from './panels/LintPanel';
+import AIPanel from './panels/AIPanel';
 
 const tabs = [
   { id: 'toc', label: 'TOC' },
@@ -36,12 +38,8 @@ export default function Inspector() {
         {inspectorTab === 'emoji' && <EmojiPanel />}
         {inspectorTab === 'snippets' && <SnippetLibrary />}
         {inspectorTab === 'assets' && <AssetPicker />}
-        {inspectorTab === 'lint' && (
-          <div className="text-sm text-muted">TODO: lint report</div>
-        )}
-        {inspectorTab === 'ai' && (
-          <div className="text-sm text-muted">TODO: AI suggestions</div>
-        )}
+        {inspectorTab === 'lint' && <LintPanel />}
+        {inspectorTab === 'ai' && <AIPanel />}
       </div>
     </aside>
   );

--- a/src/ui/components/editor/panels/AIPanel.tsx
+++ b/src/ui/components/editor/panels/AIPanel.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useAnalysisStore } from '../../../state/analysis';
+
+export default function AIPanel() {
+  const { aiSuggestions } = useAnalysisStore();
+  if (!aiSuggestions.length)
+    return <div className="text-sm text-muted">Sem sugestões no momento.</div>;
+
+  return (
+    <ul className="text-sm space-y-2">
+      {aiSuggestions.map((s, i) => (
+        <li key={i} className="border border-dashed rounded p-2 bg-subtle">
+          {s}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/ui/components/editor/panels/LintPanel.tsx
+++ b/src/ui/components/editor/panels/LintPanel.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useAnalysisStore } from '../../../state/analysis';
+
+export default function LintPanel() {
+  const { lintIssues } = useAnalysisStore();
+  if (!lintIssues.length)
+    return <div className="text-sm text-muted">Nenhuma análise disponível.</div>;
+
+  return (
+    <ul className="text-sm space-y-2">
+      {lintIssues.map((issue, idx) => (
+        <li
+          key={idx}
+          className={`border border-dashed rounded p-2 bg-subtle ${
+            issue.sev === 'err'
+              ? 'border-red-500'
+              : issue.sev === 'warn'
+              ? 'border-amber-500'
+              : 'opacity-80'
+          }`}
+        >
+          {issue.msg}
+          {issue.line && (
+            <span className="text-muted ml-1">(linha {issue.line})</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/ui/state/analysis.ts
+++ b/src/ui/state/analysis.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type Issue = { sev: string; msg: string; line?: number };
+
+type AnalysisState = {
+  lintIssues: Issue[];
+  aiSuggestions: string[];
+  setLintIssues: (issues: Issue[]) => void;
+  setAISuggestions: (sugs: string[]) => void;
+};
+
+export const useAnalysisStore = create<AnalysisState>((set) => ({
+  lintIssues: [],
+  aiSuggestions: [],
+  setLintIssues: (issues) => set({ lintIssues: issues }),
+  setAISuggestions: (aiSuggestions) => set({ aiSuggestions }),
+}));


### PR DESCRIPTION
## O que foi feito
- conecta resultados de lint e sugestões de IA ao Inspector
- adiciona store de análise com painéis dedicados

## Como testar
- `pnpm test`
- `pnpm lint` (pede configuração interativa do ESLint)

## Notas
- sugestões de IA ainda são heurísticas simples


------
https://chatgpt.com/codex/tasks/task_e_68a5d2825f68832ba4c43cb1f6f027b7