### PR TITLE
feat: add confirm dialog component

### DIFF
--- a/src/ui/components/common/ConfirmDialog.tsx
+++ b/src/ui/components/common/ConfirmDialog.tsx
@@ -1,4 +1,45 @@
 "use client";
-export default function ConfirmDialog() {
-  return null; // TODO: confirm dialog
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import Button from "@ui/components/ui/button";
+
+export interface ConfirmDialogProps {
+  /** Controls visibility of the dialog */
+  open: boolean;
+  /** Message displayed to the user */
+  message: string;
+  /** Called when the user confirms the action */
+  onConfirm: () => void;
+  /** Optional callback for cancellation */
+  onCancel?: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const [mounted, setMounted] = useState(false);
+
+  // Ensure the dialog renders only on the client side
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div className="modal">
+      <div className="box">
+        <p>{message}</p>
+        <div className="actions">
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm}>Confirm</Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
 }


### PR DESCRIPTION
## What was done
- implement reusable confirm dialog with message and callbacks

## How to test
- `npm test`
- `npm run lint` (prompts for config, no lint run)


------
https://chatgpt.com/codex/tasks/task_e_68a5d15834c4832bb9ffdb69b13f9f09