### PR TITLE
feat: add snippet library panel

### DIFF
--- a/src/ui/components/editor/panels/SnippetLibrary.tsx
+++ b/src/ui/components/editor/panels/SnippetLibrary.tsx
@@ -1,8 +1,65 @@
 "use client";
+
+import { useState } from "react";
+import { useEditorStore } from "../../../state/editor";
+import { snippets, snippetCategories } from "../snippets";
+
 export default function SnippetLibrary() {
+  const { content, setContent } = useEditorStore();
+  const [category, setCategory] = useState<string>("all");
+  const [query, setQuery] = useState("");
+
+  const filtered = snippets.filter((s) => {
+    const matchCat = category === "all" || s.category === category;
+    const matchQuery = s.label.toLowerCase().includes(query.toLowerCase());
+    return matchCat && matchQuery;
+  });
+
+  const insert = (text: string) => {
+    const sep = content.endsWith("\n") ? "" : "\n";
+    setContent(content + sep + text);
+  };
+
   return (
-    <div className="text-sm text-muted">
-      TODO: snippet library
+    <div className="flex flex-col gap-2 text-sm">
+      <div className="flex gap-2 items-center">
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="border rounded px-1 text-xs"
+        >
+          <option value="all">Todas</option>
+          {snippetCategories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar"
+          className="border rounded px-1 flex-1 text-xs"
+        />
+      </div>
+      <ul className="space-y-2">
+        {filtered.map((s) => (
+          <li key={s.id}>
+            <button
+              className="w-full text-left border rounded p-2 hover:bg-subtle"
+              onClick={() => insert(s.content)}
+            >
+              <div className="font-medium">{s.label}</div>
+              <pre className="text-xs whitespace-pre-wrap mt-1 text-muted">
+                {s.content}
+              </pre>
+            </button>
+          </li>
+        ))}
+        {filtered.length === 0 && (
+          <li className="text-muted">Nenhum snippet encontrado</li>
+        )}
+      </ul>
     </div>
   );
 }

--- a/src/ui/components/editor/snippets.ts
+++ b/src/ui/components/editor/snippets.ts
@@ -1,0 +1,53 @@
+// Preset snippets available in the editor's snippet library
+// Keep content small; users can customise after inserting
+
+export type Snippet = {
+  id: string;
+  label: string;
+  category: string;
+  content: string;
+};
+
+export const snippetCategories = ["Sections", "Badges"];
+
+export const snippets: Snippet[] = [
+  {
+    id: "section-install",
+    label: "Installation section",
+    category: "Sections",
+    content: "## Installation\n\n```bash\nnpm install\n```\n",
+  },
+  {
+    id: "section-usage",
+    label: "Usage section",
+    category: "Sections",
+    content: "## Usage\n\n```bash\nnpm start\n```\n",
+  },
+  {
+    id: "section-contributing",
+    label: "Contributing section",
+    category: "Sections",
+    content: "## Contributing\n\nPull requests are welcome.\n",
+  },
+  {
+    id: "section-license",
+    label: "License section",
+    category: "Sections",
+    content: "## License\n\nMIT\n",
+  },
+  {
+    id: "badge-build",
+    label: "Build badge",
+    category: "Badges",
+    content:
+      "![Build](https://img.shields.io/badge/build-passing-brightgreen)\n",
+  },
+  {
+    id: "badge-license",
+    label: "License badge",
+    category: "Badges",
+    content:
+      "![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)\n",
+  },
+];
+


### PR DESCRIPTION
## O que foi feito
- implementa biblioteca de snippets com filtro por categoria
- permite inserir snippet no conteúdo do editor

## Como testar
- `pnpm test`
- abrir painel **Snippets** no editor e inserir um item

## Notas
- lint interativo do Next.js falha sem configuração


------
https://chatgpt.com/codex/tasks/task_e_68a5d28584d0832ba4849089c9355dd2