### PR TITLE
fix: use context object in readme route

### DIFF
--- a/src/app/api/repos/[owner]/[repo]/readme/route.ts
+++ b/src/app/api/repos/[owner]/[repo]/readme/route.ts
@@ -4,14 +4,18 @@ import { findInstallationIdForRepo } from "@/lib/github/installations";
 
 export const runtime = "nodejs";
 
-export async function GET(_: NextRequest, { params }: { params: { owner: string; repo: string } }) {
-  const installationId = await findInstallationIdForRepo(params.owner, params.repo);
+export async function GET(
+  req: NextRequest,
+  context: any
+) {
+  const { owner, repo } = context.params as { owner: string; repo: string };
+  const installationId = await findInstallationIdForRepo(owner, repo);
   const octokit = await githubApp.getInstallationOctokit(installationId);
 
   try {
     const { data } = await octokit.request("GET /repos/{owner}/{repo}/readme", {
-      owner: params.owner,
-      repo: params.repo,
+      owner,
+      repo,
       mediaType: { format: "raw" },
     });
     return new NextResponse(data as unknown as BodyInit, {


### PR DESCRIPTION
## O que foi feito
- Refatorada rota de README para usar `context` e variáveis `owner`/`repo`.

## Como testar
- `pnpm test`
- `pnpm build` *(falha: Type error em `src/app/editor/[owner]/[repo]/page.tsx`)*

## Notas
- Build geral não passou devido ao erro acima, mas a rota modificada não apresentou problemas.


------
https://chatgpt.com/codex/tasks/task_e_68a5d62de754832bbf3d534fddf42980