### PR TITLE
feat: add cookie-based session lookup

### DIFF
--- a/src/app/api/github/oauth/callback/route.ts
+++ b/src/app/api/github/oauth/callback/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
     return res;
   }
 
-  const session = await getSessionUser(req);
+  const session = await getSessionUser();
   if (!session) {
     const res = NextResponse.redirect(new URL("/?github=unauthenticated", req.url));
     res.cookies.delete(STATE_COOKIE);

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,19 +1,20 @@
-import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
 
 export interface SessionUser {
   id: number;
 }
 
+const SESSION_COOKIE = "session_user_id";
+
 /**
- * Placeholder session lookup.
+ * Retrieve the current authenticated user from a session cookie.
  *
- * TODO: replace header-based lookup with real session management
- * (e.g. cookies or NextAuth).
+ * This implementation assumes the user's id is stored in a cookie and
+ * should be replaced with a full session mechanism (e.g. NextAuth) when
+ * available.
  */
-export async function getSessionUser(
-  req: NextRequest
-): Promise<SessionUser | null> {
-  const id = req.headers.get("x-user-id");
+export async function getSessionUser(): Promise<SessionUser | null> {
+  const id = cookies().get(SESSION_COOKIE)?.value;
   return id ? { id: Number(id) } : null;
 }
 


### PR DESCRIPTION
## O que foi feito
- replace header-based session lookup with cookie-based helper
- update GitHub OAuth callback to use new session API

## Como testar
- `pnpm test`

## Notas
- ESLint configuration missing; `pnpm lint` prompts setup


------
https://chatgpt.com/codex/tasks/task_e_68a5df95df70832b9918e0aa02a0917f