### PR TITLE
feat: fetch repos with real installation id

### DIFF
--- a/src/github/fetch.js
+++ b/src/github/fetch.js
@@ -18,9 +18,18 @@ async function getJSON(path, params) {
   return r.json();
 }
 
+/**
+ * Fetch GitHub App installations available to the user.
+ * @returns {Promise<{ items: { installation_id: number; account_login?: string }[] }>}
+ */
 export const discoverInstallations = () =>
   getJSON('/discover/installations');
 
+/**
+ * Fetch repositories for a given installation.
+ * @param {number} installation_id - GitHub App installation ID.
+ * @returns {Promise<{ items: { owner: string; repo: string; full_name: string }[] }>}
+ */
 export const discoverRepos = (installation_id) =>
   getJSON('/discover/repos', { installation_id });
 

--- a/src/ui/components/data/RepoPicker.tsx
+++ b/src/ui/components/data/RepoPicker.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useRepoStore } from '@ui/state/repo';
 import Button from '@ui/components/ui/button';
 import Modal from '@ui/components/ui/modal';
-import { discoverRepos } from '@/github/fetch';
+import { discoverInstallations, discoverRepos } from '@/github/fetch';
 
 type RepoItem = {
   owner: string;
@@ -24,8 +24,10 @@ export default function RepoPicker({
     if (!open) return;
     async function load() {
       try {
-        // TODO: supply the real installation id
-        const data = await discoverRepos(undefined as any);
+        const inst = await discoverInstallations();
+        const installationId = inst.items?.[0]?.installation_id;
+        if (!installationId) throw new Error('no installation');
+        const data = await discoverRepos(installationId);
         setRepos(data.items ?? []);
       } catch {
         setRepos([]);


### PR DESCRIPTION
## O que foi feito
- obtém a instalação do GitHub App e usa o ID real no `RepoPicker`
- documenta `discoverRepos` e `discoverInstallations` com tipos JSDoc

## Como testar
- `pnpm test`
- `pnpm lint` (requer configuração do ESLint)

## Notas
- assume a primeira instalação retornada quando houver múltiplas


------
https://chatgpt.com/codex/tasks/task_e_68a5dfa59424832b955442f92b54d087