### PR TITLE
fix: handle Next.js 15 page props

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/src/app/editor/[owner]/[repo]/page.tsx
+++ b/src/app/editor/[owner]/[repo]/page.tsx
@@ -1,7 +1,16 @@
-export default function Page({ params }: { params: { owner: string; repo: string } }) {
+// Next.js 15: `params` e `searchParams` são Promises.
+// Use o helper global `PageProps` para tipar pelo literal de rota
+// e **aguarde** `props.params` antes de acessar owner/repo.
+
+// (opcional) import explícito do tipo — o helper é global, mas isso ajuda o TS intellisense
+import type { PageProps } from 'next';
+
+export default async function Page(props: PageProps<'/editor/[owner]/[repo]'>) {
+  const { owner, repo } = await props.params; // ⬅️ await obrigatório no Next 15
+
   return (
     <main className="p-6 space-y-2">
-      <h1 className="text-xl font-semibold">Editor: {params.owner}/{params.repo}</h1>
+      <h1 className="text-xl font-semibold">Editor: {owner}/{repo}</h1>
       <p>Conecte seu GitHub App e carregue o README abaixo.</p>
     </main>
   );


### PR DESCRIPTION
## O que foi feito
- Corrige `app/editor/[owner]/[repo]/page.tsx` para aguardar `params` com `PageProps`.
- Remove `experimental.serverActions` de `next.config.js`.

## Como testar
- `pnpm build`

## Notas
- `pnpm build` atualmente falha: Property 'content' does not exist em `src/app/api/github/file/route.ts`.


------
https://chatgpt.com/codex/tasks/task_e_68a5f91a3008832badb8e9d01870030a