### PR TITLE
chore: type environment variables

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,13 +2,13 @@
 
 declare namespace NodeJS {
   interface ProcessEnv {
-    GITHUB_APP_ID?: 1797390;
+    GITHUB_APP_ID?: string;
     GITHUB_APP_CLIENT_ID?: string;
     GITHUB_APP_CLIENT_SECRET?: string;
-    GITHUB_APP_WEBHOOK_SECRET?: abc123;
+    GITHUB_APP_WEBHOOK_SECRET?: string;
     GITHUB_APP_PRIVATE_KEY_B64?: string;
     NEXT_PUBLIC_POSTHOG_KEY?: string;
-    DATABASE_URL?: 'http://localhost:3001';
+    DATABASE_URL?: string;
   }
 }
 


### PR DESCRIPTION
## O que foi feito
- declare todos os valores de ambiente como `string` em `env.d.ts`

## Como testar
- `pnpm test`
- `npx tsc -p tsconfig.json --noEmit` (ainda reporta erros de tipagem existentes)
- `pnpm lint` (falha: requer configuração do ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68a608cc8a28832b88cafd580b0a74ed