### PR TITLE
chore: check for sync page params

### DIFF
--- a/.github/workflows/lint-pages.yml
+++ b/.github/workflows/lint-pages.yml
@@ -1,0 +1,21 @@
+name: lint pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:pages

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "node --test",
     "start": "next start",
     "build": "next build",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:pages": "./scripts/find-next15-params.sh"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "latest",

--- a/scripts/find-next15-params.sh
+++ b/scripts/find-next15-params.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+if [ -d src ]; then
+  cd src
+fi
+
+if rg -n --glob '!node_modules' --glob 'app/**/page.tsx' 'export default (async )?function Page\s*\(\s*\{?\s*params\s*:'; then
+  echo
+  echo "Found page components with synchronous params. Refactor for Next.js 15."
+  exit 1
+fi


### PR DESCRIPTION
## O que foi feito
- adiciona script que falha se páginas exportarem `params` síncrono
- configura workflow do GitHub Actions para rodar essa verificação

## Como testar
- `pnpm lint:pages`


------
https://chatgpt.com/codex/tasks/task_e_68a60d69b704832bafac51089b40b0a7