### PR TITLE
chore: use react-jsx jsx runtime

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "react",
       "react-dom"
     ],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- set `compilerOptions.jsx` to `react-jsx`

## Testing
- `pnpm install`
- `pnpm lint --fix` *(fails: Unexpected any, unused vars, etc.)*
- `pnpm eslint . --ext .ts,.tsx --fix` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm build` *(fails: TypeScript lint errors during Next.js build)*
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm exec tsc --noEmit` *(fails: Cannot find type definition file for 'node', 'react', 'vite/client')*
- `bash scripts/audit-next15.sh` *(fails: No such file or directory)*
- `bash scripts/smoke.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a647fa7ea4832b8b2a49eb8bf3078b