### PR TITLE
chore: add React type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/mysql": "^2.15.27",
     "@types/pg": "^8.15.5",
     "@types/pg-pool": "^2.0.6",
+    "@types/react": "19.x",
     "@types/react-dom": "^19.1.7",
     "@types/tedious": "^4.0.14",
     "@typescript-eslint/eslint-plugin": "^8.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@types/pg-pool':
         specifier: ^2.0.6
         version: 2.0.6
+      '@types/react':
+        specifier: 19.x
+        version: 19.1.10
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.10)


### PR DESCRIPTION
## Summary
- add `@types/react` 19.x to devDependencies
- update lockfile for React type definitions

## Testing
- `pnpm install`
- `pnpm lint --fix` *(fails: Unexpected any, no-unused-vars, no-img-element)*
- `pnpm tsc --noEmit` *(fails: Cannot find type definition file for 'node' and 'vite/client')*
- `pnpm build` *(fails: lint errors)*
- `bash scripts/audit-next15.sh` *(fails: script not found)*
- `bash scripts/smoke.sh` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a647ffe594832b9f3ffbed55c1f71d