### PR TITLE
chore: add Next 15 audit script

### DIFF
--- a/.github/workflows/lint-pages.yml
+++ b/.github/workflows/lint-pages.yml
@@ -19,3 +19,4 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint:pages
+      - run: bash scripts/audit-next15.sh

--- a/scripts/audit-next15.sh
+++ b/scripts/audit-next15.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FAIL=0
+
+# Duplicatas de app roots
+if git ls-files 'app/**/page.*' | grep -q . && git ls-files 'src/app/**/page.*' | grep -q .; then
+  echo "❌ Duplicated app roots (app/ and src/app/)"; FAIL=1; fi
+
+# PageProps/params sync
+rg -n --glob '!node_modules' --glob '!*.d.ts' \
+  'export default (async )?function Page\s*\(\s*\{?\s*params\s*:\s*\{' src/app app && { echo "❌ Pages com params síncrono"; FAIL=1; } || true
+
+# RouteContext params sem await
+rg -n 'ctx\.params\.' src/app app && { echo "❌ ctx.params usado sem await"; FAIL=1; } || true
+
+# cookies()/headers() sem await
+rg -n 'cookies\(\)\.(get|set|delete)' src app && { echo "❌ cookies() sem await"; FAIL=1; } || true
+rg -n 'headers\(\)\.' src app && { echo "❌ headers() sem await"; FAIL=1; } || true
+
+# Type-only imports (Toast exemplo)
+rg -n "import\s*\{[^}]*\bToast\b[^}]*\}\s*from\s*'@ui/state/toast'" src app && { echo "❌ Toast import não-type"; FAIL=1; } || true
+
+exit $FAIL


### PR DESCRIPTION
## Summary
- add Next 15 audit script covering duplicate app roots, async params, un-awaited cookies/headers, and toast imports
- run audit script in the CI workflow

## Testing
- `pnpm lint --fix` *(fails: Unexpected any. Specify a different type.)*
- `pnpm build` *(fails: Linting and checking validity of types)*
- `bash scripts/audit-next15.sh`
- `bash test/smoke.sh` *(fails: unexpected EOF while looking for matching ``'`*)

------
https://chatgpt.com/codex/tasks/task_e_68a6480017c4832bb94d3240e6e06606