### PR TITLE
test: mock useEmoji flag

### DIFF
--- a/emojiHelpers.js
+++ b/emojiHelpers.js
@@ -1,0 +1,39 @@
+const EMO = {
+  'Header com Badges': '🏷️',
+  'Resumo': '📝',
+  'Instalação': '⚙️',
+  'Uso': '🚀',
+  'Exemplos': '🧪',
+  'Screenshots': '🖼️',
+  'Roadmap': '🗺️',
+  'Contribuindo': '🤝',
+  'Licença': '📄',
+  'Sumário': '🧭',
+  'Nome do Projeto': '📦'
+};
+
+function startsWithEmoji(s) {
+  try {
+    return /^[\u2190-\u2BFF\u2600-\u27BF\u{1F000}-\u{1FAFF}]/u.test((s || '').trim());
+  } catch {
+    return false;
+  }
+}
+
+function emojifyLine(hashes, title) {
+  if (!globalThis.useEmoji?.checked) return `${hashes} ${title}`;
+  if (startsWithEmoji(title)) return `${hashes} ${title}`;
+  const t = title.trim();
+  const exact = EMO[t] || EMO[t.replace(/:.*/, '')];
+  if (exact) return `${hashes} ${exact} ${title}`;
+  for (const k in EMO) {
+    if (t.toLowerCase().includes(k.toLowerCase())) return `${hashes} ${EMO[k]} ${title}`;
+  }
+  return `${hashes} ${title}`;
+}
+
+function applyEmojis(md) {
+  return md.replace(/^(#{1,6})\s+([^\n]+)$/gm, (m, hashes, title) => emojifyLine(hashes, title));
+}
+
+module.exports = { EMO, startsWithEmoji, emojifyLine, applyEmojis };

--- a/tests/emojiHelpers.test.js
+++ b/tests/emojiHelpers.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { applyEmojis } = require('../emojiHelpers.js');
+
+test('Headings starting with emoji remain unchanged', () => {
+  global.useEmoji = { checked: true };
+  const input = '# ⚙️ Instalação';
+  const output = applyEmojis(input);
+  assert.equal(output, '# ⚙️ Instalação');
+});
+
+test('Known section titles receive the correct emoji', () => {
+  global.useEmoji = { checked: true };
+  const input = '# Instalação';
+  const output = applyEmojis(input);
+  assert.equal(output, '# ⚙️ Instalação');
+});
+
+test('Partial matches work', () => {
+  global.useEmoji = { checked: true };
+  const input = '# Instalação rápida';
+  const output = applyEmojis(input);
+  assert.equal(output, '# ⚙️ Instalação rápida');
+});
+
+test('Headings with unknown titles remain unchanged', () => {
+  global.useEmoji = { checked: true };
+  const input = '# Random';
+  const output = applyEmojis(input);
+  assert.equal(output, '# Random');
+});
+
+test('No emoji added when useEmoji flag is off', () => {
+  global.useEmoji = { checked: false };
+  const input = '# Instalação';
+  const output = applyEmojis(input);
+  assert.equal(output, '# Instalação');
+});


### PR DESCRIPTION
## Summary
- add standalone emoji helpers module for testing
- mock useEmoji flag in tests for emoji helpers

## Testing
- `node tests/emojiHelpers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a64df700a8832b8d7b55951dfcd32b