### PR TITLE
refactor: modularize toolbar binding

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,10 @@
 
-import { bindUI as bindUIImported } from '@ui/bindToolbar';
-import { log as logImported } from './utils/log';
-
-const bindUI: () => void = bindUIImported;
-const log: (...args: unknown[]) => void = logImported;
+import { bindToolbar } from '@ui/bindToolbar';
+import { log } from './utils/log';
 
 log('Env', {
   protocol: location.protocol,
   host: location.host,
   href: location.href,
 });
-bindUI();
+bindToolbar();


### PR DESCRIPTION
## Summary
- centralize toast element and lint rendering outside toolbar binding
- group snippet buttons into helper `bindInsertionTools`
- rename exported `bindToolbar` and update main entry

## Testing
- `pnpm lint` *(fails: Unexpected any, unused vars, no-img-element)*
- `pnpm test` *(fails: No test suite found in file test/lint.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d2343e4832ba836d03085ef06f3