### PR TITLE
feat: use typed diff-match-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "lint:pages": "./scripts/find-next15-params.sh"
   },
-  "dependencies": {    
-  "packageManager": "pnpm@9"
+  "packageManager": "pnpm@9.0.0",
+  "dependencies": {
+    "diff-match-patch-es": "^1.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(next@15.5.0(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      diff-match-patch:
-        specifier: ^1.0.5
-        version: 1.0.5
+      diff-match-patch-es:
+        specifier: ^1.0.1
+        version: 1.0.1
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -2310,8 +2310,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff-match-patch@1.0.5:
-    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
+  diff-match-patch-es@1.0.1:
+    resolution: {integrity: sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ==}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -6747,7 +6747,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff-match-patch@1.0.5: {}
+  diff-match-patch-es@1.0.1: {}
 
   diff@4.0.2: {}
 

--- a/src/ui/components/editor/AnalysisBar.tsx
+++ b/src/ui/components/editor/AnalysisBar.tsx
@@ -3,7 +3,7 @@ import Button from '../ui/button';
 import { useEditorStore } from '../../state/editor';
 import { useState } from 'react';
 import { lintMarkdown, type LintMarkdownResult } from '../../../utils/lint';
-import DiffMatchPatch from 'diff-match-patch';
+import { diff as diffStrings, diffCleanupSemantic, diffPrettyHtml } from 'diff-match-patch-es';
 import { useAnalysisStore } from '../../state/analysis';
 
 export default function AnalysisBar({
@@ -30,10 +30,9 @@ export default function AnalysisBar({
   };
 
   const preview = () => {
-    const dmp = new DiffMatchPatch();
-    const diff = dmp.diff_main(original, content);
-    dmp.diff_cleanupSemantic(diff);
-    setDiffHtml(dmp.diff_prettyHtml(diff));
+    const diffs = diffStrings(original, content);
+    diffCleanupSemantic(diffs);
+    setDiffHtml(diffPrettyHtml(diffs));
   };
 
   return (
@@ -58,3 +57,4 @@ export default function AnalysisBar({
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- use `diff-match-patch-es` for semantic diffing in the editor
- update lockfile and package manifest

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: vitest: not found)*

Mudança guiada por agent_ui

------
https://chatgpt.com/codex/tasks/task_e_68a772578ab8832bbdc1736b209e7468