### PR TITLE
feat(api): add structured webhook logging

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest} from "next/server";
 import { NextResponse } from "next/server";
 import { verifyGitHubWebhook } from "@/lib/github/verify";
 import { prisma } from "@/lib/db/client";
+import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -39,15 +40,16 @@ export async function POST(req: NextRequest) {
 
   switch (event) {
     case "push":
-      console.log(
-        "push",
-        payload.repository?.full_name,
-        payload.head_commit?.id,
-        payload.head_commit?.message
-      );
+      logger.info("github.push", {
+        repo: payload.repository?.full_name,
+        commit: payload.head_commit?.id,
+        message: payload.head_commit?.message,
+      });
       break;
     case "installation":
-      console.log("installation", payload.installation?.id);
+      logger.info("github.installation", {
+        installationId: payload.installation?.id,
+      });
       break;
     default:
       break;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,9 @@
+export interface LogData {
+  [key: string]: unknown;
+}
+
+export const logger = {
+  info: (msg: string, data: LogData = {}): void => {
+    console.log(JSON.stringify({ level: "info", msg, ...data }));
+  }
+};

--- a/test/githubWebhookLogging.test.ts
+++ b/test/githubWebhookLogging.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => {
+  class NextRequest extends Request {}
+  const NextResponse = {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: { 'content-type': 'application/json', ...(init?.headers || {}) }
+      })
+  };
+  return { NextRequest, NextResponse };
+});
+
+vi.mock('@/lib/github/verify', () => ({
+  verifyGitHubWebhook: () => true
+}));
+
+vi.mock('@/lib/db/client', () => ({
+  prisma: { installation: { upsert: vi.fn(() => Promise.resolve()) } }
+}));
+import { POST } from '@/app/api/github/webhook/route';
+import { logger } from '@/lib/logger';
+
+describe('github webhook logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(logger, 'info').mockImplementation(() => {});
+    process.env.GITHUB_APP_WEBHOOK_SECRET = 'test';
+  });
+
+  test('logs push event', async () => {
+    const payload = {
+      installation: { id: 1, account: { login: 'user', id: 2 } },
+      repository: { full_name: 'owner/repo' },
+      head_commit: { id: 'abc', message: 'msg' }
+    };
+    const req = new Request('https://example.com/api', {
+      method: 'POST',
+      headers: {
+        'x-github-event': 'push',
+        'x-hub-signature-256': 'sha256=test'
+      },
+      body: JSON.stringify(payload)
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(logger.info).toHaveBeenCalledWith('github.push', {
+      repo: 'owner/repo',
+      commit: 'abc',
+      message: 'msg'
+    });
+  });
+
+  test('logs installation event', async () => {
+    const payload = { installation: { id: 2, account: { login: 'user', id: 3 } } };
+    const req = new Request('https://example.com/api', {
+      method: 'POST',
+      headers: {
+        'x-github-event': 'installation',
+        'x-hub-signature-256': 'sha256=test'
+      },
+      body: JSON.stringify(payload)
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(logger.info).toHaveBeenCalledWith('github.installation', {
+      installationId: 2
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace console logging in GitHub webhook handler with structured logger
- cover push and installation events with tests

## Testing
- `npx vitest run`

Mudança guiada por agent_github

------
https://chatgpt.com/codex/tasks/task_e_68a7e2e7c9f4832b81ece885c73a32a6