### PR TITLE
Fix asset picker import and logging

### DIFF
--- a/src/ui/components/editor/Inspector.tsx
+++ b/src/ui/components/editor/Inspector.tsx
@@ -6,7 +6,8 @@ import SnippetLibrary from './panels/SnippetLibrary';
 import LintPanel from './panels/LintPanel';
 import AIPanel from './panels/AIPanel';
 import { useState, useEffect } from "react";
-import AssetPicker, { type Asset } from "./panels//AssetPicker";
+import AssetPicker, { type Asset } from "./panels/AssetPicker";
+import { log } from '@/utils/log';
 
 const tabs = [
   { id: 'toc', label: 'TOC' },
@@ -30,7 +31,7 @@ export default function Inspector() {
 
   // exemplo de seleção de asset (aqui só log; integre com seu editor se quiser)
   const handleSelect = (asset: Asset) => {
-    console.log("Selecionado:", asset);
+    log('Selecionado:', asset);
     // Ex.: inserir markdown na área de edição
     // setContent(prev => `${prev}\n\n![${asset.name}](${asset.url})`);
   };


### PR DESCRIPTION
## Summary
- fix asset picker import path
- replace console.log with log helper in Inspector

## Testing
- `pnpm lint` *(fails: 'setDiffHtml' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2c438d0832b9b72583b620d926b