### PR TITLE
refactor backend url config

### DIFF
--- a/src/github/config.js
+++ b/src/github/config.js
@@ -1,5 +1,21 @@
 // src/github/config.js
 // Troque a URL abaixo pelo endereço público do seu backend quando subir (Render/CF Workers).
 // Em dev, pode apontar para o túnel ngrok (https://xxxxx.ngrok.app) ou localhost se abrir local.
-export const BACKEND_URL = localStorage.getItem('READMESTUDIO_BACKEND_URL')
-  || 'http://127.0.0.1:3000';
+
+let cachedUrl;
+
+export function getBackendUrl() {
+  if (cachedUrl) return cachedUrl;
+  if (typeof window !== 'undefined') {
+    try {
+      cachedUrl =
+        window.localStorage.getItem('READMESTUDIO_BACKEND_URL') ||
+        'http://127.0.0.1:3000';
+    } catch {
+      cachedUrl = 'http://127.0.0.1:3000';
+    }
+  } else {
+    cachedUrl = 'http://127.0.0.1:3000';
+  }
+  return cachedUrl;
+}


### PR DESCRIPTION
## Summary
- refactor backend config to provide a `getBackendUrl` helper that caches the result

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e8f21704832bb6a4b03c89deea7b