### PR TITLE
Use Octokit for default branch discovery

### DIFF
--- a/src/github/fetch.ts
+++ b/src/github/fetch.ts
@@ -91,17 +91,14 @@ export async function discoverReadme(
 }
 
 async function discoverDefaultBranch(owner: string, repo: string): Promise<string> {
-  const url = `https://api.github.com/repos/${owner}/${repo}`;
+  const octokit = getOctokit();
   try {
-    const r = await fetch(url);
-    const data = await r.json().catch(() => ({} as { default_branch?: string }));
-    if (!r.ok) {
-      if (r.status === 404) throw new Error('NOT_FOUND_REPO_OR_PRIVATE');
-      throw new Error('Falha ao obter repo');
-    }
+    const { data } = await octokit.rest.repos.get({ owner, repo });
     return data.default_branch || 'main';
-  } catch (e) {
-    throw new Error('NETWORK_FAILURE');
+  } catch (e: any) {
+    if (!('status' in (e ?? {}))) throw new Error('NETWORK_FAILURE');
+    if (e.status === 404) throw new Error('NOT_FOUND_REPO_OR_PRIVATE');
+    throw new Error('Falha ao obter repo');
   }
 }
 

--- a/test/discoverDefaultBranch.test.ts
+++ b/test/discoverDefaultBranch.test.ts
@@ -1,12 +1,20 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
+
 
 (globalThis as unknown as { localStorage: Storage }).localStorage = {
-  getItem: (_: string): string | null => null
+  getItem: (_: string): string | null => null,
 };
 
 (globalThis as unknown as { document: Document }).document = {
-  getElementById: (_: string): HTMLElement | null => null
+  getElementById: (_: string): HTMLElement | null => null,
 } as Document;
+
+const mockGet = vi.fn();
+vi.mock('octokit', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    rest: { repos: { get: mockGet } },
+  })),
+}));
 
 const { __TESTING__ } = await import('../src/github/fetch.ts');
 const { discoverDefaultBranch } = __TESTING__ as {
@@ -14,19 +22,13 @@ const { discoverDefaultBranch } = __TESTING__ as {
 };
 
 test('discoverDefaultBranch uses API default_branch', async () => {
-  const originalFetch: typeof fetch = global.fetch;
-  global.fetch = async (): Promise<Response> =>
-    new Response(JSON.stringify({ default_branch: 'dev' }), { status: 200 });
+  mockGet.mockResolvedValue({ data: { default_branch: 'dev' } });
   const branch: string = await discoverDefaultBranch('owner', 'repo');
   expect(branch).toBe('dev');
-  global.fetch = originalFetch;
 });
 
 test('discoverDefaultBranch defaults to main when absent', async () => {
-  const originalFetch: typeof fetch = global.fetch;
-  global.fetch = async (): Promise<Response> =>
-    new Response('{}', { status: 200 });
+  mockGet.mockResolvedValue({ data: {} });
   const branch: string = await discoverDefaultBranch('owner', 'repo');
   expect(branch).toBe('main');
-  global.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- rely on Octokit to determine a repository's default branch
- reuse shared getOctokit helper for authentication
- mock Octokit in tests instead of fetch

Mudança guiada por agent_github

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e92d7140832ba744bfce0d031c20