### PR TITLE
Avoid server-side localStorage access in analytics setup

### DIFF
--- a/src/github/config.js
+++ b/src/github/config.js
@@ -1,5 +1,9 @@
 // src/github/config.js
 // Troque a URL abaixo pelo endereço público do seu backend quando subir (Render/CF Workers).
 // Em dev, pode apontar para o túnel ngrok (https://xxxxx.ngrok.app) ou localhost se abrir local.
-export const BACKEND_URL = localStorage.getItem('READMESTUDIO_BACKEND_URL')
-  || 'http://127.0.0.1:3000';
+const DEFAULT_BACKEND_URL = 'http://127.0.0.1:3000';
+export const BACKEND_URL =
+  typeof window !== 'undefined'
+    ? window.localStorage.getItem('READMESTUDIO_BACKEND_URL') ||
+      DEFAULT_BACKEND_URL
+    : DEFAULT_BACKEND_URL;

--- a/src/lib/utils/providers.tsx
+++ b/src/lib/utils/providers.tsx
@@ -1,8 +1,6 @@
 "use client";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode, type ComponentType } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { PostHogProvider } from "posthog-js/react";
-import posthog from "posthog-js";
 import { I18nextProvider } from "react-i18next";
 import i18n from "./i18n";
 
@@ -14,27 +12,40 @@ declare global {
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [qc] = useState(() => new QueryClient());
+  const [posthog, setPosthog] = useState<any>(null);
+  const [PostHogProvider, setPostHogProvider] =
+    useState<ComponentType<{ client: any }> | null>(null);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (window.__PHInitialized) return;
+    if (typeof window === "undefined" || window.__PHInitialized) return;
 
-    const token = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-    if (token) {
-      posthog.init(token, {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://app.posthog.com",
-        capture_pageview: true,
-        capture_pageleave: true,
-      });
-      window.__PHInitialized = true;
-    }
+    Promise.all([import("posthog-js"), import("posthog-js/react")]).then(
+      ([ph, react]) => {
+        const client = ph.default;
+        const token = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+        if (token) {
+          client.init(token, {
+            api_host:
+              process.env.NEXT_PUBLIC_POSTHOG_HOST ||
+              "https://app.posthog.com",
+            capture_pageview: true,
+            capture_pageleave: true,
+          });
+          window.__PHInitialized = true;
+        }
+        setPosthog(client);
+        setPostHogProvider(() => react.PostHogProvider);
+      }
+    );
   }, []);
 
-  return (
-    <PostHogProvider client={posthog}>
-      <I18nextProvider i18n={i18n}>
-        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-      </I18nextProvider>
-    </PostHogProvider>
+  const content = (
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </I18nextProvider>
   );
+
+  if (!PostHogProvider || !posthog) return content;
+
+  return <PostHogProvider client={posthog}>{content}</PostHogProvider>;
 }


### PR DESCRIPTION
## Summary
- load PostHog analytics dynamically so server prerender no longer touches `localStorage`
- guard GitHub backend URL resolution behind a window check

Mudança guiada por agent_ui.

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'vitest')*
- `pnpm run build --no-lint` *(fails: Property 'login' does not exist on type)*
- `pnpm lint` *(fails: Failed to load config "next/core-web-vitals")*


------
https://chatgpt.com/codex/tasks/task_e_68a7e96a373c832b9eb24eddb6203984