### PR TITLE
Guard log DOM access for Node environments

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,8 @@ log('Env', {
   href: location.href,
 });
 
-const rootEl = document.getElementById('app');
+const rootEl =
+  typeof document !== 'undefined' ? document.getElementById('app') : null;
 if (rootEl) {
   createRoot(rootEl).render(<App />);
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -11,12 +11,14 @@ export function log(...args: unknown[]): void {
     .join(' ');
   const ts = new Date().toISOString().slice(11, 19);
   LOG.push(`[${ts}] ${line}`);
-  const panel = document.getElementById('dbgPanel') as HTMLElement | null;
-  const toggle = document.getElementById('showDbg') as HTMLInputElement | null;
-  if (panel && toggle?.checked) {
-    panel.hidden = false;
-    panel.textContent = LOG.join('\n');
-    panel.scrollTop = panel.scrollHeight;
+  if (typeof document !== 'undefined') {
+    const panel = document.getElementById('dbgPanel') as HTMLElement | null;
+    const toggle = document.getElementById('showDbg') as HTMLInputElement | null;
+    if (panel && toggle?.checked) {
+      panel.hidden = false;
+      panel.textContent = LOG.join('\n');
+      panel.scrollTop = panel.scrollHeight;
+    }
   }
   console.log('[README-STUDIO]', ...args);
 }

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test, vi } from 'vitest';
+import { log, getLogText } from '@/utils/log';
+
+describe('log', () => {
+  test('runs in a Node environment', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    log('hello', { a: 1 });
+    expect(getLogText()).toMatch(/hello/);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- guard DOM queries in log utility with `typeof document` checks
- ensure main entry safely resolves root element
- add unit test verifying `log()` works when no DOM is present

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e91460a8832bb055e4791a47a4ec