### PR TITLE
feat(ui): improve modal accessibility

### DIFF
--- a/src/ui/components/ui/modal.tsx
+++ b/src/ui/components/ui/modal.tsx
@@ -1,14 +1,29 @@
 "use client";
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren, useEffect } from 'react';
 
 export default function Modal({
   open,
   onClose,
   children,
 }: PropsWithChildren<{ open: boolean; onClose: () => void }>) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
   if (!open) return null;
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 bg-black/50 flex items-center justify-center"
       onClick={onClose}
     >


### PR DESCRIPTION
## Summary
- add dialog semantics to modal overlay
- close modal on Escape key for keyboard users

Mudança guiada por agent_ui

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d55d9e40832ba093d5716127cb9e