### PR TITLE
fix: add aria-labels to toolbar buttons

### DIFF
--- a/src/ui/components/editor/Toolbar.tsx
+++ b/src/ui/components/editor/Toolbar.tsx
@@ -62,13 +62,41 @@ export default function Toolbar({
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
-      <Button variant="secondary" onClick={withView((v) => wrapSelection(v, '**'))}>
+      <Button
+        variant="secondary"
+        onClick={withView((v) => wrapSelection(v, '**'))}
+        aria-label="bold"
+      >
         <b>B</b>
       </Button>
-      <Button variant="secondary" onClick={withView(insertHeading)}>H1</Button>
-      <Button variant="secondary" onClick={withView(insertList)}>•</Button>
-      <Button variant="secondary" onClick={withView(insertCode)}>&lt;/&gt;</Button>
-      <Button variant="secondary" onClick={insertToc}>☰</Button>
+      <Button
+        variant="secondary"
+        onClick={withView(insertHeading)}
+        aria-label="heading"
+      >
+        H1
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={withView(insertList)}
+        aria-label="unordered list"
+      >
+        •
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={withView(insertCode)}
+        aria-label="code block"
+      >
+        &lt;/&gt;
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={insertToc}
+        aria-label="table of contents"
+      >
+        ☰
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve accessibility by labeling editor toolbar buttons

## Testing
- `pnpm lint`
- `pnpm test`

Mudança guiada por **agent_ui**, **agent_docs**.

------
https://chatgpt.com/codex/tasks/task_e_68a8d55c5670832bad96bfe89d9c0af8