### PR TITLE
feat: set default button type

### DIFF
--- a/src/ui/components/ui/button.tsx
+++ b/src/ui/components/ui/button.tsx
@@ -6,6 +6,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 export default function Button({
   children,
   variant = 'default',
+  type = 'button',
   ...props
 }: React.PropsWithChildren<ButtonProps>) {
   const base = 'px-3 py-1 rounded';
@@ -15,7 +16,7 @@ export default function Button({
     outline: 'border border-accent text-accent',
   };
   return (
-    <button className={`${base} ${styles[variant] ?? styles.default}`} {...props}>
+    <button type={type} className={`${base} ${styles[variant] ?? styles.default}`} {...props}>
       {children}
     </button>
   );


### PR DESCRIPTION
## Summary
- ensure Button defaults to `type="button"` and forwards it to the DOM to avoid unintended form submissions

Mudança guiada por agent_ui.

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d55efcb4832ba37f93c0d052e2a2