### PR TITLE
Fix global styles not loading

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import '@ui/styles/globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/pages/layout.tsx
+++ b/src/app/pages/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import '@ui/styles/globals.css';
 import { usePathname } from 'next/navigation';
 import AppSidebar from '@ui/components/shell/AppSidebar';
 import { Providers } from '@/lib/utils/providers';


### PR DESCRIPTION
## Summary
- introduce root layout that imports global styles
- remove stray global stylesheet import from nested layout

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f0f94f5c832baea2ae8490a131c9