### PR TITLE
feat: secure github routes

### DIFF
--- a/src/app/api/github/oauth/start/route.ts
+++ b/src/app/api/github/oauth/start/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import { githubApp } from "@/lib/github/app";
+import { getSessionUser } from "@/lib/auth/session";
 
 export const runtime = "nodejs";
 
 const STATE_COOKIE = "gh_oauth_state";
 
 export async function GET() {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
   const state = randomUUID();
   const { url } = await githubApp.oauth.getWebFlowAuthorizationUrl({ state });
   const res = NextResponse.redirect(url);

--- a/src/app/api/github/pr/route.ts
+++ b/src/app/api/github/pr/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { githubApp } from "@/lib/github/app";
-import { findInstallationIdForRepo } from "@/lib/github/installations";
+import { findAuthorizedInstallationIdForRepo } from "@/lib/github/installations";
+import { getSessionUser } from "@/lib/auth/session";
 import { z } from "zod";
 
 export const runtime = "nodejs";
@@ -16,6 +17,11 @@ const schema = z.object({
 });
 
 export async function POST(req: Request) {
+  const session = await getSessionUser();
+  if (!session) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
   const json = await req.json().catch(() => null);
   const parsed = schema.safeParse(json);
   if (!parsed.success) {
@@ -28,7 +34,14 @@ export async function POST(req: Request) {
   const { owner, repo, title, body, head, base } = parsed.data;
 
   try {
-    const installationId = await findInstallationIdForRepo(owner, repo);
+    const installationId = await findAuthorizedInstallationIdForRepo(
+      owner,
+      repo,
+      session.id,
+    );
+    if (!installationId) {
+      return NextResponse.json({ error: "FORBIDDEN" }, { status: 403 });
+    }
     const octokit = await githubApp.getInstallationOctokit(installationId);
     const { data } = await octokit.request("POST /repos/{owner}/{repo}/pulls", {
       owner,

--- a/src/lib/github/installations.ts
+++ b/src/lib/github/installations.ts
@@ -1,5 +1,6 @@
 import { githubApp } from "@/lib/github/app";
 import { prisma } from "@/lib/db/client";
+import { Octokit } from "octokit";
 
 /**
  * Resolve installation id for a repo, caching in Prisma.
@@ -16,4 +17,28 @@ export async function findInstallationIdForRepo(owner: string, repo: string): Pr
     data: { owner, repo, installationId: data.id },
   });
   return data.id;
+}
+
+/**
+ * Resolve installation id for a repo, ensuring the given user has access.
+ * Returns null if the user is not authorized for the installation.
+ */
+export async function findAuthorizedInstallationIdForRepo(
+  owner: string,
+  repo: string,
+  userId: number,
+): Promise<number | null> {
+  const installationId = await findInstallationIdForRepo(owner, repo);
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  const token = user?.githubAccessToken;
+  if (!token) return null;
+  const octokit = new Octokit({ auth: token });
+  try {
+    await octokit.request("GET /user/installations/{installation_id}", {
+      installation_id: installationId,
+    });
+    return installationId;
+  } catch {
+    return null;
+  }
 }

--- a/test/githubRoutesAuth.test.ts
+++ b/test/githubRoutesAuth.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("next/server", () => {
+  class NextRequest extends Request {}
+  const NextResponse = {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: { "content-type": "application/json", ...(init?.headers || {}) },
+      }),
+  };
+  return { NextRequest, NextResponse };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  getSessionUser: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/lib/github/app", () => ({
+  githubApp: { getInstallationOctokit: vi.fn() },
+}));
+
+vi.mock("@/lib/github/installations", () => ({
+  findAuthorizedInstallationIdForRepo: vi.fn(),
+}));
+
+import { POST as BranchPOST } from "@/app/api/github/branch/route";
+import { GET as FileGET } from "@/app/api/github/file/route";
+import { POST as PrPOST } from "@/app/api/github/pr/route";
+
+describe("github route auth", () => {
+  test("branch POST rejects unauthenticated", async () => {
+    const req = new Request("https://example.com/api", {
+      method: "POST",
+      body: JSON.stringify({
+        owner: "o",
+        repo: "r",
+        newBranch: "b",
+        fromSha: "s",
+      }),
+    });
+    const res = await BranchPOST(req);
+    expect(res.status).toBe(401);
+  });
+
+  test("file GET rejects unauthenticated", async () => {
+    const req = new Request("https://example.com/api?owner=o&repo=r&path=p");
+    const res = await FileGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  test("pr POST rejects unauthenticated", async () => {
+    const req = new Request("https://example.com/api", {
+      method: "POST",
+      body: JSON.stringify({
+        owner: "o",
+        repo: "r",
+        title: "t",
+        body: "b",
+        head: "h",
+        base: "m",
+      }),
+    });
+    const res = await PrPOST(req);
+    expect(res.status).toBe(401);
+  });
+});
+


### PR DESCRIPTION
## Summary
- require session and installation ownership for GitHub API routes
- check session before starting OAuth
- add tests for unauthenticated GitHub route access

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9225ef800832ba18b03ef126272ac